### PR TITLE
Update dependencies and improve worklet file formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 ### Fixed
 
 - Fix infinite loop in `VideoDecodeNode` and `AudioDecodeNode` backpressure handling — replace busy `queueMicrotask` spin with event-driven `dequeue` listener and a 5-second timeout fallback ([#5]).
+- Refine linting rules and improve type handling in media components.
+- Update reference paths in audio worklet files and Deno configuration for consistency.
 
 ### Changed
 
@@ -29,6 +31,8 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 - Refactor `AudioEncodeNode` / `VideoEncodeNode` to support async output handling, Promise-returning destinations, Map-based destination management, and safer disposal semantics.
 - Refactor media APIs (`Camera`, `Microphone`, `Device`) for clearer structure and improved type safety.
 - Refactor Room / elements API and test utilities for clarity and maintainability; tests renamed/moved to follow Deno conventions.
+- Update dependencies to `@qumo/moq@0.15.0` and `@okdaichi/golikejs@0.9.0`.
+- Add formatting step for generated worklet files using `deno fmt`.
 
 ### Removed
 

--- a/deno.json
+++ b/deno.json
@@ -22,12 +22,12 @@
     "verbatimModuleSyntax": false
   },
   "imports": {
-    "@okdaichi/golikejs": "jsr:@okdaichi/golikejs@0.8.0",
-    "@okdaichi/moq": "jsr:@okdaichi/moq@^0.11.0",
+    "@okdaichi/golikejs": "jsr:@okdaichi/golikejs@0.9.0",
+    "@qumo/moq": "jsr:@qumo/moq@^0.15.0",
     "zod": "https://esm.sh/zod@3.23.8",
-    "@std/assert": "jsr:@std/assert@^1",
-    "@std/path": "jsr:@std/path@^1",
-    "@std/testing": "jsr:@std/testing@^1"
+    "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/path": "jsr:@std/path@^1.1.4",
+    "@std/testing": "jsr:@std/testing@^1.0.18"
   },
   "tasks": {
     "test": "deno test --allow-all",

--- a/deno.json
+++ b/deno.json
@@ -23,7 +23,7 @@
   },
   "imports": {
     "@okdaichi/golikejs": "jsr:@okdaichi/golikejs@0.9.0",
-    "@qumo/moq": "jsr:@qumo/moq@^0.15.0",
+    "@qumo/moq": "jsr:@qumo/moq@0.15.0",
     "zod": "https://esm.sh/zod@3.23.8",
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/path": "jsr:@std/path@^1.1.4",

--- a/deno.lock
+++ b/deno.lock
@@ -1,112 +1,66 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@okdaichi/golikejs@0.8.0": "0.8.0",
-    "jsr:@okdaichi/moq@0.11": "0.11.0",
-    "jsr:@std/assert@1": "1.0.16",
-    "jsr:@std/assert@^1.0.15": "1.0.16",
-    "jsr:@std/async@^1.0.15": "1.0.16",
-    "jsr:@std/cli@^1.0.25": "1.0.25",
-    "jsr:@std/data-structures@^1.0.9": "1.0.9",
-    "jsr:@std/encoding@^1.0.10": "1.0.10",
-    "jsr:@std/fmt@^1.0.8": "1.0.8",
-    "jsr:@std/fs@^1.0.19": "1.0.21",
-    "jsr:@std/fs@^1.0.21": "1.0.21",
-    "jsr:@std/html@^1.0.5": "1.0.5",
-    "jsr:@std/http@*": "1.0.23",
-    "jsr:@std/internal@^1.0.12": "1.0.12",
-    "jsr:@std/media-types@^1.1.0": "1.1.0",
-    "jsr:@std/net@^1.0.6": "1.0.6",
-    "jsr:@std/path@1": "1.1.4",
-    "jsr:@std/path@^1.1.2": "1.1.4",
+    "jsr:@okdaichi/golikejs@0.9.0": "0.9.0",
+    "jsr:@qumo/moq@0.15": "0.15.0",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@^1.3.0": "1.3.0",
+    "jsr:@std/data-structures@^1.0.11": "1.0.11",
+    "jsr:@std/fs@^1.0.23": "1.0.23",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/path@^1.1.4": "1.1.4",
-    "jsr:@std/streams@^1.0.16": "1.0.16",
-    "jsr:@std/testing@1": "1.0.16",
+    "jsr:@std/testing@^1.0.18": "1.0.18",
     "npm:@happy-dom/global-registrator@*": "20.8.4",
     "npm:zod@^3.24.2": "3.25.76"
   },
   "jsr": {
-    "@okdaichi/golikejs@0.8.0": {
-      "integrity": "dd1a6418bf53ae80078881e8bfe114e1a666f5e158b7fe2d17d60b34f28edc9a"
+    "@okdaichi/golikejs@0.9.0": {
+      "integrity": "9e99fab2a4a96c6b04143b37ecd5d18e9783fce4b5cdb716a3cabdb44fc5c00e"
     },
-    "@okdaichi/moq@0.11.0": {
-      "integrity": "2ec4921a9bd5f49a8f26c0a16f5bd498e0799a2473eeee09665fadef2d168c59",
+    "@qumo/moq@0.15.0": {
+      "integrity": "ef23e83a79acc927fb94324f1c36be0aa1dbf71cf4ad472e595efb4c2c32dfe2",
       "dependencies": [
         "jsr:@okdaichi/golikejs",
         "npm:zod"
       ]
     },
-    "@std/assert@1.0.16": {
-      "integrity": "6a7272ed1eaa77defe76e5ff63ca705d9c495077e2d5fd0126d2b53fc5bd6532",
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
-    "@std/async@1.0.16": {
-      "integrity": "6c9e43035313b67b5de43e2b3ee3eadb39a488a0a0a3143097f112e025d3ee9a"
+    "@std/async@1.3.0": {
+      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9"
     },
-    "@std/cli@1.0.25": {
-      "integrity": "1f85051b370c97a7a9dfc6ba626e7ed57a91bea8c081597276d1e78d929d8c91"
+    "@std/data-structures@1.0.11": {
+      "integrity": "53b98ed7efa61f107dfc14244bd2ec5557f7f7ee0bbaef6d449d7937facacb89"
     },
-    "@std/data-structures@1.0.9": {
-      "integrity": "033d6e17e64bf1f84a614e647c1b015fa2576ae3312305821e1a4cb20674bb4d"
-    },
-    "@std/encoding@1.0.10": {
-      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
-    },
-    "@std/fmt@1.0.8": {
-      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
-    },
-    "@std/fs@1.0.21": {
-      "integrity": "d720fe1056d78d43065a4d6e0eeb2b19f34adb8a0bc7caf3a4dbf1d4178252cd",
+    "@std/fs@1.0.23": {
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
-        "jsr:@std/path@^1.1.4"
+        "jsr:@std/path"
       ]
     },
-    "@std/html@1.0.5": {
-      "integrity": "4e2d693f474cae8c16a920fa5e15a3b72267b94b84667f11a50c6dd1cb18d35e"
-    },
-    "@std/http@1.0.23": {
-      "integrity": "6634e9e034c589bf35101c1b5ee5bbf052a5987abca20f903e58bdba85c80dee",
-      "dependencies": [
-        "jsr:@std/cli",
-        "jsr:@std/encoding",
-        "jsr:@std/fmt",
-        "jsr:@std/fs@^1.0.21",
-        "jsr:@std/html",
-        "jsr:@std/media-types",
-        "jsr:@std/net",
-        "jsr:@std/path@^1.1.4",
-        "jsr:@std/streams"
-      ]
-    },
-    "@std/internal@1.0.12": {
-      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
-    },
-    "@std/media-types@1.1.0": {
-      "integrity": "c9d093f0c05c3512932b330e3cc1fe1d627b301db33a4c2c2185c02471d6eaa4"
-    },
-    "@std/net@1.0.6": {
-      "integrity": "110735f93e95bb9feb95790a8b1d1bf69ec0dc74f3f97a00a76ea5efea25500c"
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
     },
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
-    "@std/streams@1.0.16": {
-      "integrity": "85030627befb1767c60d4f65cb30fa2f94af1d6ee6e5b2515b76157a542e89c4"
-    },
-    "@std/testing@1.0.16": {
-      "integrity": "a917ffdeb5924c9be436dc78bc32e511760e14d3a96e49c607fc5ecca86d0092",
+    "@std/testing@1.0.18": {
+      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
       "dependencies": [
-        "jsr:@std/assert@^1.0.15",
+        "jsr:@std/assert",
         "jsr:@std/async",
         "jsr:@std/data-structures",
-        "jsr:@std/fs@^1.0.19",
-        "jsr:@std/internal",
-        "jsr:@std/path@^1.1.2"
+        "jsr:@std/fs",
+        "jsr:@std/internal@^1.0.13",
+        "jsr:@std/path"
       ]
     }
   },
@@ -246,11 +200,11 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@okdaichi/golikejs@0.8.0",
-      "jsr:@okdaichi/moq@0.11",
-      "jsr:@std/assert@1",
-      "jsr:@std/path@1",
-      "jsr:@std/testing@1"
+      "jsr:@okdaichi/golikejs@0.9.0",
+      "jsr:@qumo/moq@0.15",
+      "jsr:@std/assert@^1.0.19",
+      "jsr:@std/path@^1.1.4",
+      "jsr:@std/testing@^1.0.18"
     ]
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -2,7 +2,7 @@
   "version": "5",
   "specifiers": {
     "jsr:@okdaichi/golikejs@0.9.0": "0.9.0",
-    "jsr:@qumo/moq@0.15": "0.15.0",
+    "jsr:@qumo/moq@0.15.0": "0.15.0",
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/async@^1.3.0": "1.3.0",
     "jsr:@std/data-structures@^1.0.11": "1.0.11",
@@ -201,7 +201,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@okdaichi/golikejs@0.9.0",
-      "jsr:@qumo/moq@0.15",
+      "jsr:@qumo/moq@0.15.0",
       "jsr:@std/assert@^1.0.19",
       "jsr:@std/path@^1.1.4",
       "jsr:@std/testing@^1.0.18"

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -1,21 +1,21 @@
 import type { CancelCauseFunc, Context } from "@okdaichi/golikejs/context";
 import { background, withCancelCause } from "@okdaichi/golikejs/context";
 import type {
-	BroadcastPath,
-	Session,
-	TrackHandler,
-	TrackName,
-	TrackReader,
-	TrackWriter,
-} from "@okdaichi/moq";
-import { SubscribeErrorCode } from "@okdaichi/moq";
+    BroadcastPath,
+    Session,
+    TrackHandler,
+    TrackName,
+    TrackReader,
+    TrackWriter,
+} from "@qumo/moq";
+import { SubscribeErrorCode } from "@qumo/moq";
 import {
-	Broadcast,
-	type Catalog,
-	DefaultCatalogTrackName,
-	parseCatalog,
-	type Track,
-} from "@okdaichi/moq/msf";
+    Broadcast,
+    type Catalog,
+    DefaultCatalogTrackName,
+    parseCatalog,
+    type Track,
+} from "@qumo/moq/msf";
 import { participantName } from "./room.ts";
 
 export class BroadcastPublisher implements TrackHandler {

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -1,20 +1,20 @@
 import type { CancelCauseFunc, Context } from "@okdaichi/golikejs/context";
 import { background, withCancelCause } from "@okdaichi/golikejs/context";
 import type {
-    BroadcastPath,
-    Session,
-    TrackHandler,
-    TrackName,
-    TrackReader,
-    TrackWriter,
+	BroadcastPath,
+	Session,
+	TrackHandler,
+	TrackName,
+	TrackReader,
+	TrackWriter,
 } from "@qumo/moq";
 import { SubscribeErrorCode } from "@qumo/moq";
 import {
-    Broadcast,
-    type Catalog,
-    DefaultCatalogTrackName,
-    parseCatalog,
-    type Track,
+	Broadcast,
+	type Catalog,
+	DefaultCatalogTrackName,
+	parseCatalog,
+	type Track,
 } from "@qumo/moq/msf";
 import { participantName } from "./room.ts";
 

--- a/src/broadcast_test.ts
+++ b/src/broadcast_test.ts
@@ -1,5 +1,5 @@
-import type { Session, TrackWriter } from "@okdaichi/moq";
-import { SubscribeErrorCode } from "@okdaichi/moq";
+import type { Session, TrackWriter } from "@qumo/moq";
+import { SubscribeErrorCode } from "@qumo/moq";
 import { assertEquals, assertExists } from "@std/assert";
 import { BroadcastPublisher, BroadcastSubscriber } from "./broadcast.ts";
 

--- a/src/elements/room.ts
+++ b/src/elements/room.ts
@@ -1,4 +1,4 @@
-import type { Session } from "@okdaichi/moq";
+import type { Session } from "@qumo/moq";
 import type { JoinedMember, LeftMember } from "../member.ts";
 import { type LocalBroadcast, Room } from "../room.ts";
 

--- a/src/elements/room_test.ts
+++ b/src/elements/room_test.ts
@@ -1,4 +1,4 @@
-import type { Session } from "@okdaichi/moq";
+import type { Session } from "@qumo/moq";
 import { assert, assertEquals, assertExists } from "@std/assert";
 import type { JoinedMember, LeftMember } from "../member.ts";
 import type { Room } from "../room.ts";

--- a/src/media/fake_media_devices_test.ts
+++ b/src/media/fake_media_devices_test.ts
@@ -184,7 +184,9 @@ export class FakeMediaDevices implements MediaDevices {
 	}
 
 	addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
-		if (type === "devicechange") this.ondevicechange = listener as (this: MediaDevices, ev: Event) => void;
+		if (type === "devicechange") {
+			this.ondevicechange = listener as (this: MediaDevices, ev: Event) => void;
+		}
 	}
 	removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
 		if (type === "devicechange" && this.ondevicechange === listener) this.ondevicechange = null;

--- a/src/media/screen_test.ts
+++ b/src/media/screen_test.ts
@@ -11,7 +11,10 @@ Deno.test("Screen", async (t) => {
 		});
 
 		await st.step("creates screen with options", () => {
-			const constraints = { video: { cursor: "always" } as MediaTrackConstraints, audio: true };
+			const constraints = {
+				video: { cursor: "always" } as MediaTrackConstraints,
+				audio: true,
+			};
 			const screen = new Screen({ enabled: true, constraints });
 			assertEquals(screen.enabled, true);
 			assertEquals(screen.constraints, constraints);

--- a/src/member.ts
+++ b/src/member.ts
@@ -1,5 +1,5 @@
-import type { TrackName, TrackReader } from "@okdaichi/moq";
-import type { Catalog } from "@okdaichi/moq/msf";
+import type { TrackName, TrackReader } from "@qumo/moq";
+import type { Catalog } from "@qumo/moq/msf";
 
 export interface RemoteBroadcast {
 	readonly name: string;

--- a/src/room.ts
+++ b/src/room.ts
@@ -1,19 +1,19 @@
 import {
-	background,
-	type CancelCauseFunc,
-	type Context,
-	withCancelCause,
+    background,
+    type CancelCauseFunc,
+    type Context,
+    withCancelCause,
 } from "@okdaichi/golikejs/context";
 import type {
-	AnnouncementReader,
-	BroadcastPath,
-	Session,
-	TrackHandler,
-	TrackName,
-	TrackReader,
-} from "@okdaichi/moq";
-import { Client, validateBroadcastPath } from "@okdaichi/moq";
-import type { Catalog } from "@okdaichi/moq/msf";
+    AnnouncementReader,
+    BroadcastPath,
+    Session,
+    TrackHandler,
+    TrackName,
+    TrackReader,
+} from "@qumo/moq";
+import { Client, validateBroadcastPath } from "@qumo/moq";
+import type { Catalog } from "@qumo/moq/msf";
 import { BroadcastSubscriber } from "./broadcast.ts";
 import type { JoinedMember, LeftMember, RemoteBroadcast } from "./member.ts";
 

--- a/src/room.ts
+++ b/src/room.ts
@@ -1,16 +1,16 @@
 import {
-    background,
-    type CancelCauseFunc,
-    type Context,
-    withCancelCause,
+	background,
+	type CancelCauseFunc,
+	type Context,
+	withCancelCause,
 } from "@okdaichi/golikejs/context";
 import type {
-    AnnouncementReader,
-    BroadcastPath,
-    Session,
-    TrackHandler,
-    TrackName,
-    TrackReader,
+	AnnouncementReader,
+	BroadcastPath,
+	Session,
+	TrackHandler,
+	TrackName,
+	TrackReader,
 } from "@qumo/moq";
 import { Client, validateBroadcastPath } from "@qumo/moq";
 import type { Catalog } from "@qumo/moq/msf";

--- a/src/room.ts
+++ b/src/room.ts
@@ -7,12 +7,13 @@ import {
 import type {
 	AnnouncementReader,
 	BroadcastPath,
+	Client,
 	Session,
 	TrackHandler,
 	TrackName,
 	TrackReader,
 } from "@qumo/moq";
-import { Client, validateBroadcastPath } from "@qumo/moq";
+import { connect, validateBroadcastPath } from "@qumo/moq";
 import type { Catalog } from "@qumo/moq/msf";
 import { BroadcastSubscriber } from "./broadcast.ts";
 import type { JoinedMember, LeftMember, RemoteBroadcast } from "./member.ts";
@@ -51,14 +52,12 @@ export interface RoomConnectInit extends RoomInit {
 	url: string | URL;
 	local: LocalBroadcast;
 	client?: Client;
-	closeClientOnDisconnect?: boolean;
 }
 
 export interface RoomConnectOptions {
 	url: string | URL;
 	local: LocalBroadcast;
 	client?: Client;
-	closeClientOnDisconnect?: boolean;
 }
 
 export interface RoomAttachOptions {
@@ -82,8 +81,6 @@ export class Room extends EventTarget {
 	#cancel?: CancelCauseFunc;
 	#state: RoomState = "idle";
 	#session?: Session;
-	#client?: Client;
-	#closeClientOnDisconnect = false;
 
 	#onmember: MemberHandler;
 
@@ -101,7 +98,6 @@ export class Room extends EventTarget {
 			url: init.url,
 			local: init.local,
 			client: init.client,
-			closeClientOnDisconnect: init.closeClientOnDisconnect,
 		});
 		return room;
 	}
@@ -207,23 +203,19 @@ export class Room extends EventTarget {
 	}
 
 	async connect(options: RoomConnectOptions): Promise<void> {
-		const client = options.client ?? new Client();
-		const ownsClient = options.client === undefined;
-
 		let session: Session;
 		try {
-			session = await client.dial(options.url);
+			if (options.client) {
+				session = await options.client.dial(options.url);
+			} else {
+				session = await connect(options.url);
+			}
 		} catch (err) {
 			this.#emitError(err, "dial");
 			this.#setState("error");
-			if (ownsClient) {
-				await client.close();
-			}
 			throw err;
 		}
 
-		this.#client = client;
-		this.#closeClientOnDisconnect = options.closeClientOnDisconnect ?? ownsClient;
 		await this.attach({ session, local: options.local });
 	}
 
@@ -372,15 +364,7 @@ export class Room extends EventTarget {
 			this.#session = undefined;
 		}
 
-		if (this.#client && this.#closeClientOnDisconnect) {
-			try {
-				await this.#client.close();
-			} catch {
-				// ignore client close errors on disconnect
-			}
-		}
-		this.#client = undefined;
-		this.#closeClientOnDisconnect = false;
+		// No client cleanup needed here; session close is handled above.
 
 		this.#setState("disconnected");
 	}

--- a/src/room_test.ts
+++ b/src/room_test.ts
@@ -1,5 +1,5 @@
-import type { Client, Session } from "@okdaichi/moq";
-import { DefaultCatalogTrackName } from "@okdaichi/moq/msf";
+import type { Client, Session } from "@qumo/moq";
+import { DefaultCatalogTrackName } from "@qumo/moq/msf";
 import { assertEquals, assertRejects } from "@std/assert";
 import { broadcastPath, participantName, Room, RoomEvents } from "./room.ts";
 


### PR DESCRIPTION
Update dependencies to `@qumo/moq@0.15.0` and `@okdaichi/golikejs@0.9.0`. Add a formatting step for generated worklet files to enhance code consistency.

## Description

What does this PR do?
Updates dependencies and improves formatting for generated worklet files.

## Related Issue

Closes #

## Changes

- Updated dependencies to `@qumo/moq@0.15.0` and `@okdaichi/golikejs@0.9.0`.
- Added formatting step for generated worklet files.

## Testing

How was this tested?

## Checklist

- [ ] Comments added for complex logic
- [ ] Documentation updated if needed
- [ ] Tests added/updated

