### PR TITLE
fix(AudioEncodeNode): break busy-spin loop under encoder backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 ### Fixed
 
 - Fix infinite loop in `VideoDecodeNode` and `AudioDecodeNode` backpressure handling — replace busy `queueMicrotask` spin with event-driven `dequeue` listener and a 5-second timeout fallback ([#5]).
+- Fix infinite loop in `AudioEncodeNode` encoder backpressure — wait for the encoder `dequeue` event (with a 5-second timeout) instead of busy-spinning via `queueMicrotask`, and stop reading the stream when the drain times out ([#12]).
 
 ### Changed
 
@@ -72,3 +73,4 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 [Unreleased]: https://github.com/okdaichi/moqrtc-js/compare/main...copilot/migrate-to-deno-runtime
 ["#3"]: https://github.com/okdaichi/moqrtc-js/pull/3
 [#5]: https://github.com/okdaichi/moqrtc-js/pull/5
+[#12]: https://github.com/okdaichi/moqrtc-js/pull/12

--- a/packages/av_nodes/audio/encode_node.ts
+++ b/packages/av_nodes/audio/encode_node.ts
@@ -185,7 +185,15 @@ export class AudioEncodeNode extends GainNode {
 				return;
 			}
 
-			await this.#waitForEncoderDrain(5000);
+			const drained = await this.#waitForEncoderDrain(5000);
+			if (!drained) {
+				console.warn(
+					"[AudioEncodeNode] Encoder stalled, stopping stream reads after timeout.",
+				);
+				stream.releaseLock();
+				return;
+			}
+
 			queueMicrotask(() => this.#next(stream));
 			return;
 		}

--- a/packages/av_nodes/audio/encode_node.ts
+++ b/packages/av_nodes/audio/encode_node.ts
@@ -170,12 +170,22 @@ export class AudioEncodeNode extends GainNode {
 			return;
 		}
 
-		// Backpressure: Drop frame if queue is overloaded
+		// Backpressure: When queue is overloaded, drop this frame but wait for the
+		// encoder to actually drain before reading the next one. Rescheduling via
+		// queueMicrotask without waiting busy-spins forever while the worklet
+		// keeps producing frames, starving the encoder of any chance to catch up.
 		if (this.encodeQueueSize > MAX_ENCODE_QUEUE_SIZE) {
 			console.warn(
-				`[AudioEncodeNode] Dropping frame, queue size: ${this.encodeQueueSize}`,
+				`[AudioEncodeNode] Dropping frame, queue size: ${this.encodeQueueSize}, waiting for drain...`,
 			);
 			value.close();
+
+			if (this.#encoder.state === "closed") {
+				stream.releaseLock();
+				return;
+			}
+
+			await this.#waitForEncoderDrain(5000);
 			queueMicrotask(() => this.#next(stream));
 			return;
 		}
@@ -197,6 +207,39 @@ export class AudioEncodeNode extends GainNode {
 		clonedData.close();
 
 		queueMicrotask(() => this.#next(stream));
+	}
+
+	#waitForEncoderDrain(timeoutMs: number): Promise<boolean> {
+		return new Promise<boolean>((resolve) => {
+			let settled = false;
+
+			const finish = (drained: boolean) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timeoutId);
+				this.#encoder.removeEventListener("dequeue", onDequeue);
+				resolve(drained);
+			};
+
+			const onDequeue = () => {
+				finish(true);
+			};
+
+			const timeoutId = setTimeout(() => {
+				finish(false);
+			}, timeoutMs);
+
+			this.#encoder.addEventListener("dequeue", onDequeue, { once: true });
+
+			// Re-check immediately after attaching the listener so we don't miss
+			// a drain transition that happened just before listener registration.
+			if (
+				this.#encoder.state !== "configured" ||
+				this.encodeQueueSize <= MAX_ENCODE_QUEUE_SIZE
+			) {
+				finish(true);
+			}
+		});
 	}
 
 	// Codec state monitoring


### PR DESCRIPTION
## Problem

`AudioEncodeNode` could enter an unstoppable infinite loop. When the encoder queue was overloaded, `#next` dropped the frame and rescheduled itself via `queueMicrotask(() => this.#next(stream))` with **no wait** for the encoder to drain.

The audio worklet produces frames continuously, so `stream.read()` resolved on every microtask, the overload check stayed true, and the node spun forever in a tight microtask loop. This starved the encoder of the macrotasks it needs to emit output and shrink `encodeQueueSize`, so the queue could never drain — a self-sustaining busy-spin.

The other three nodes don't have this bug:
- `AudioDecodeNode` / `VideoDecodeNode` wait on the decoder's real `dequeue` event (`#waitForDecoderDrain`, 5s timeout) before re-reading.
- `VideoEncodeNode` drops frames inline in `process()` with no recursion.

## Fix

Gave `AudioEncodeNode` the same drain-wait pattern the decode nodes already use:
- Added `#waitForEncoderDrain(timeoutMs)` — listens for the encoder's `dequeue` event, re-checks immediately after attaching (to avoid missing a transition), and bounds the wait with a 5s timeout.
- In the overloaded branch: drop the current frame, then `await this.#waitForEncoderDrain(5000)` before rescheduling. If the encoder is closed, release the reader and stop.

This breaks the busy-spin: the loop now yields to the event loop and lets the encoder make progress.

## Verification
- `deno check` clean on the modified file.
- `AudioEncodeNode` tests: 3 passed (37 steps), including all backpressure tests.
- Full `av_nodes` suite: 58 passed / 1 failed — the single failure is in `VideoAnalyserNode` and reproduces identically on the base commit (`ca45190`), so it's pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)