### PR TITLE
perf(AudioEncodeNode): drop redundant clone in #next encode path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 - Refactor Room / elements API and test utilities for clarity and maintainability; tests renamed/moved to follow Deno conventions.
 - Update dependencies to `@qumo/moq@0.15.0` and `@okdaichi/golikejs@0.9.0`.
 - `AudioDecodeNode`: cache the resolved worklet and post decoded frames directly instead of going through a per-frame `.then()` continuation (also guards the fast-path `postMessage` against throws so a failure can't escape into the decoder output callback) ([#14]).
+- `AudioEncodeNode`: the worklet-driven encode path (`#next`) now encodes stream-sourced frames directly instead of cloning first (the node owns those frames), cutting per-frame allocation/GC pressure; added `#next`-path test coverage and made `FakeAudioEncoder` model the `dequeue` event ([#15]).
 - Add formatting step for generated worklet files using `deno fmt`.
 
 ### Removed
@@ -76,3 +77,4 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 [#5]: https://github.com/okdaichi/moqrtc-js/pull/5
 [#12]: https://github.com/okdaichi/moqrtc-js/pull/12
 [#14]: https://github.com/okdaichi/moqrtc-js/pull/14
+[#15]: https://github.com/okdaichi/moqrtc-js/pull/15

--- a/packages/av_nodes/audio/encode_bench.ts
+++ b/packages/av_nodes/audio/encode_bench.ts
@@ -1,0 +1,155 @@
+// Audio encode #next-path harness.
+//
+// Drives the REAL production path: worklet.port.onmessage -> node-owned
+// ReadableStream -> #next (read/clone-or-not/encode/close). We feed N
+// AudioDataInit messages into the captured worklet port and wait until the
+// encoder has encoded all N.
+//
+// Scope: FakeAudioData.clone() allocates a real FakeAudioData, so the clone
+// cost IS measured (unlike video). FakeAudioEncoder models encode as a
+// microtask. Measures node-plumbing + AudioData alloc/close, not real codec.
+//
+// Run: deno run --allow-all packages/av_nodes/audio/encode_bench.ts
+
+import { FakeAudioContext } from "./fake_audio_context_test.ts";
+import { FakeAudioWorkletNode } from "./fake_audio_workletnode_test.ts";
+import { FakeAudioEncoder } from "./fake_audioencoder_test.ts";
+import { FakeAudioData } from "./fake_audiodata_test.ts";
+import { FakeGainNode } from "./fake_gainnode_test.ts";
+
+function overrideGlobal(name: string, value: unknown): () => void {
+	const g = globalThis as unknown as Record<string, unknown>;
+	const had = Object.prototype.hasOwnProperty.call(g, name);
+	const orig = g[name];
+	g[name] = value;
+	return () => {
+		if (had) g[name] = orig;
+		else delete g[name];
+	};
+}
+
+overrideGlobal("GainNode", FakeGainNode);
+
+// AudioData ctor that accepts either AudioDataInit (from worklet) or the
+// positional (frames, channels, sampleRate, ts) form used by FakeAudioData.
+class FakeAudioDataCtor extends FakeAudioData {
+	constructor(
+		initOrFrames?: unknown,
+		channels?: number,
+		sampleRate?: number,
+		timestamp?: number,
+	) {
+		if (
+			typeof initOrFrames === "object" && initOrFrames !== null
+		) {
+			const init = initOrFrames as AudioDataInit;
+			super(
+				init.numberOfFrames ?? 1024,
+				init.numberOfChannels ?? 2,
+				init.sampleRate ?? 44100,
+				init.timestamp ?? 0,
+			);
+		} else {
+			super(
+				initOrFrames as number | undefined,
+				channels,
+				sampleRate,
+				timestamp,
+			);
+		}
+	}
+}
+overrideGlobal("AudioData", FakeAudioDataCtor);
+
+// Worklet that records its instance so the harness can drive port.onmessage.
+let lastWorklet: FakeAudioWorkletNode | null = null;
+class RecordingWorklet extends FakeAudioWorkletNode {
+	constructor(
+		ctx?: BaseAudioContext,
+		name?: string,
+		opts?: AudioWorkletNodeOptions,
+	) {
+		super(ctx, name, opts);
+		lastWorklet = this;
+	}
+}
+overrideGlobal("AudioWorkletNode", RecordingWorklet);
+overrideGlobal(
+	"AudioEncoder",
+	function (this: unknown, init: AudioEncoderInit) {
+		return new FakeAudioEncoder(init);
+	},
+);
+
+const { AudioEncodeNode } = await import("./encode_node.ts");
+
+const N = 20000;
+
+function makeContext(): FakeAudioContext {
+	const ctx = new FakeAudioContext();
+	(ctx as unknown as Record<string, unknown>).state = "running";
+	return ctx;
+}
+
+async function runEncode(n: number): Promise<number> {
+	const context = makeContext();
+	const node = new AudioEncodeNode(context as unknown as AudioContext);
+	node.configure({ codec: "opus", sampleRate: 48000, numberOfChannels: 2 });
+
+	// Wait for the worklet (addModule.then) to be constructed and #next started.
+	await new Promise<void>((r) => setTimeout(r, 0));
+	await new Promise<void>((r) => setTimeout(r, 0));
+
+	const worklet = lastWorklet!;
+	const encoder = FakeAudioEncoder.lastCreated!;
+
+	const audioDataInit: AudioDataInit = {
+		numberOfFrames: 1024,
+		numberOfChannels: 2,
+		sampleRate: 48000,
+		format: "f32-planar",
+		timestamp: 0,
+		data: new Float32Array(1024 * 2),
+	};
+
+	const start = performance.now();
+	for (let i = 0; i < n; i++) {
+		audioDataInit.timestamp = i * 21333;
+		// Drive the node's worklet onmessage -> ReadableStream -> #next.
+		(worklet.port.onmessage as unknown as (
+			ev: { data: AudioDataInit },
+		) => void)({ data: audioDataInit });
+	}
+
+	// Wait until all N frames have been encoded.
+	const deadline = start + 10000;
+	while (encoder.encodeCalls.length < n && performance.now() < deadline) {
+		await new Promise<void>((r) => setTimeout(r, 0));
+	}
+	const elapsedMs = performance.now() - start;
+
+	node.dispose();
+	return elapsedMs;
+}
+
+const runs: number[] = [];
+// Force GC before each run if available (--v8-flags=--expose-gc) so the
+// comparison reflects steady-state allocation cost rather than GC scheduling
+// luck. Without this, run-to-run variance dwarfs the per-frame signal.
+const gc = (globalThis as unknown as { gc?: () => void }).gc?.bind(globalThis);
+for (let i = 0; i < 20; i++) {
+	gc?.();
+	runs.push(await runEncode(N));
+}
+runs.sort((a, b) => a - b);
+// discard warmup tails, report median + trimmed mean of the middle 12
+const mid = runs.slice(4, 16);
+const median = mid[Math.floor(mid.length / 2)] ?? 0;
+const mean = mid.reduce((s, r) => s + r, 0) / mid.length;
+console.log(
+	`audio encode #next: N=${N} frames, 20 runs (middle 12 used)`,
+);
+console.log(
+	`elapsed ms: median ${median.toFixed(2)} mean ${mean.toFixed(2)} | fps median ${(N / (median / 1000)).toFixed(0)}`,
+);
+console.log(`all runs (ms): ${runs.map((r) => r.toFixed(0)).join(", ")}`);

--- a/packages/av_nodes/audio/encode_node.ts
+++ b/packages/av_nodes/audio/encode_node.ts
@@ -198,12 +198,13 @@ export class AudioEncodeNode extends GainNode {
 			return;
 		}
 
-		// Ownership: Stream owns value, so we clone for our use
-		const clonedData = value.clone();
-		value.close(); // Close original since we cloned it
-
+		// Ownership: this node owns `value` — the ReadableStream is created in
+		// the constructor and the AudioData is constructed here from worklet
+		// messages. WebCodecs encode() captures what it needs synchronously, so
+		// we can encode directly and close immediately after — no clone needed
+		// (unlike process(), where the caller owns the frame).
 		try {
-			this.#encoder.encode(clonedData);
+			this.#encoder.encode(value);
 		} catch (e) {
 			// Only log if not a closed codec error during shutdown
 			if (!this.#disposed) {
@@ -211,8 +212,7 @@ export class AudioEncodeNode extends GainNode {
 			}
 		}
 
-		// Ownership: We own the clone, so we close it
-		clonedData.close();
+		value.close();
 
 		queueMicrotask(() => this.#next(stream));
 	}

--- a/packages/av_nodes/audio/encode_node_test.ts
+++ b/packages/av_nodes/audio/encode_node_test.ts
@@ -580,3 +580,181 @@ Deno.test("AudioEncodeNode - backpressure handling", async (t) => {
 		encodeNode.dispose();
 	});
 });
+
+// Worklet-driven #next path tests.
+//
+// The process() method is covered above, but the production encode path runs
+// through #next: the worklet posts AudioDataInit -> the node's ReadableStream
+// -> #next reads, (no longer clones), encodes, closes. These tests drive that
+// path by capturing the worklet instance and posting to its port directly.
+Deno.test("AudioEncodeNode - worklet #next path", async (t) => {
+	let restoreAudioEncoder: () => void;
+	let restoreAudioWorkletNode: () => void;
+	let restoreAudioData: () => void;
+	let context: FakeAudioContext;
+	let encodeNode: AudioEncodeNodeType;
+	let capturedWorklet: FakeAudioWorkletNode | null;
+	let cloneCallCount: number;
+
+	// AudioWorkletNode subclass that records its instance so the test can drive
+	// port.onmessage (the same path the real worklet uses to feed #next).
+	class RecordingWorklet extends FakeAudioWorkletNode {
+		constructor(
+			ctx?: BaseAudioContext,
+			name?: string,
+			opts?: AudioWorkletNodeOptions,
+		) {
+			super(ctx, name, opts);
+			capturedWorklet = this;
+		}
+	}
+
+	// AudioData that accepts AudioDataInit (as the worklet path constructs it)
+	// and counts clone() calls so we can assert #next does not clone before
+	// encoding (the node owns these frames).
+	class TestAudioData extends FakeAudioData {
+		constructor(init: AudioDataInit) {
+			super(
+				init.numberOfFrames ?? 1024,
+				init.numberOfChannels ?? 2,
+				init.sampleRate ?? 48000,
+				init.timestamp ?? 0,
+			);
+		}
+		override clone(): AudioData {
+			cloneCallCount++;
+			return super.clone();
+		}
+	}
+
+	function overrideAudioData(value: unknown): () => void {
+		const g = globalThis as unknown as Record<string, unknown>;
+		const had = Object.prototype.hasOwnProperty.call(g, "AudioData");
+		const orig = g.AudioData;
+		g.AudioData = value;
+		return () => {
+			if (had) g.AudioData = orig;
+			else delete g.AudioData;
+		};
+	}
+
+	function makeInit(timestamp: number): AudioDataInit {
+		return {
+			data: new Float32Array(1024 * 2),
+			format: "f32-planar" as AudioSampleFormat,
+			numberOfFrames: 1024,
+			numberOfChannels: 2,
+			sampleRate: 48000,
+			timestamp,
+		};
+	}
+
+	function postFrame(ts: number): void {
+		(capturedWorklet!.port.onmessage as unknown as (
+			ev: { data: AudioDataInit },
+		) => void)({ data: makeInit(ts) });
+	}
+
+	async function waitForEncodes(
+		encoder: FakeAudioEncoder,
+		n: number,
+		timeoutMs = 1000,
+	): Promise<void> {
+		const deadline = performance.now() + timeoutMs;
+		while (encoder.encodeCalls.length < n && performance.now() < deadline) {
+			await new Promise<void>((r) => setTimeout(r, 0));
+		}
+	}
+
+	await t.step("setup", async () => {
+		capturedWorklet = null;
+		cloneCallCount = 0;
+		restoreAudioEncoder = overrideAudioEncoder(FakeAudioEncoder);
+		restoreAudioWorkletNode = overrideAudioWorkletNode(RecordingWorklet);
+		restoreAudioData = overrideAudioData(TestAudioData);
+
+		context = new FakeAudioContext();
+		encodeNode = new AudioEncodeNode(context);
+		encodeNode.configure({ codec: "opus", sampleRate: 48000, numberOfChannels: 2 });
+
+		// Wait for the worklet (addModule.then) to be constructed and #next started.
+		await new Promise<void>((r) => setTimeout(r, 0));
+		await new Promise<void>((r) => setTimeout(r, 0));
+	});
+
+	await t.step("#next encodes frames received via the worklet port", async () => {
+		const encoder = FakeAudioEncoder.lastCreated!;
+		encoder.encodeCalls = [];
+		const N = 5;
+		for (let i = 0; i < N; i++) postFrame(i * 1000);
+		await waitForEncodes(encoder, N);
+
+		assertEquals(encoder.encodeCalls.length, N);
+		// Timestamps preserved through the worklet -> #next -> encode path.
+		for (let i = 0; i < N; i++) {
+			assertEquals(encoder.encodeCalls[i]!.timestamp, i * 1000);
+		}
+	});
+
+	await t.step(
+		"#next does not clone before encoding (encodes the original frame)",
+		async () => {
+			const encoder = FakeAudioEncoder.lastCreated!;
+			encoder.encodeCalls = [];
+			cloneCallCount = 0;
+
+			postFrame(4242);
+			await waitForEncodes(encoder, 1);
+
+			assertEquals(encoder.encodeCalls.length, 1);
+			// The node owns worklet-sourced frames, so #next must encode the
+			// original directly — no clone needed.
+			assertEquals(cloneCallCount, 0);
+			assert(
+				encoder.encodeCalls[0] instanceof TestAudioData,
+				"encoded frame should be the original frame, not a clone",
+			);
+		},
+	);
+
+	await t.step("#next drops frames when the encoder queue is overloaded", async () => {
+		const encoder = FakeAudioEncoder.lastCreated!;
+		encoder.encodeCalls = [];
+		encoder.encodeQueueSize = 10; // > MAX_ENCODE_QUEUE_SIZE (2)
+
+		postFrame(9999);
+		// Let #next read the frame and take the drop branch (closes frame, no encode).
+		await new Promise<void>((r) => setTimeout(r, 0));
+		await new Promise<void>((r) => setTimeout(r, 0));
+
+		assertEquals(encoder.encodeCalls.length, 0); // dropped, not encoded
+
+		// #next is now suspended in its drain wait; unblock it via the dequeue
+		// event so the test does not stall on the 5s drain timeout.
+		encoder.dispatchEvent(new Event("dequeue"));
+	});
+
+	await t.step("#next stops encoding after dispose", async () => {
+		const encoder = FakeAudioEncoder.lastCreated!;
+		encoder.encodeCalls = [];
+		encoder.encodeQueueSize = 0; // reset after the overloaded-queue step
+		for (let i = 0; i < 3; i++) postFrame(i * 100);
+		await waitForEncodes(encoder, 3);
+		const before = encoder.encodeCalls.length;
+
+		await encodeNode.dispose();
+
+		// Frames posted after dispose must not be encoded.
+		for (let i = 0; i < 3; i++) postFrame(i * 100 + 5000);
+		await new Promise<void>((r) => setTimeout(r, 10));
+		assertEquals(encoder.encodeCalls.length, before);
+	});
+
+	await t.step("cleanup", () => {
+		restoreAudioData();
+		restoreAudioWorkletNode();
+		restoreAudioEncoder();
+		restoreGlobalGainNode();
+		encodeNode.dispose();
+	});
+});

--- a/packages/av_nodes/audio/fake_audioencoder_test.ts
+++ b/packages/av_nodes/audio/fake_audioencoder_test.ts
@@ -20,7 +20,7 @@
  * Static lastCreated lets tests retrieve the most recently constructed encoder:
  *   const enc = FakeAudioEncoder.lastCreated!;
  */
-export class FakeAudioEncoder {
+export class FakeAudioEncoder extends EventTarget {
 	/** Most recently constructed instance — useful in tests where the encoder is created inside production code. */
 	static lastCreated: FakeAudioEncoder | null = null;
 
@@ -70,6 +70,7 @@ export class FakeAudioEncoder {
 	#error: WebCodecsErrorCallback;
 
 	constructor(init: AudioEncoderInit) {
+		super();
 		this.#output = init.output;
 		this.#error = init.error;
 		FakeAudioEncoder.lastCreated = this;
@@ -86,6 +87,7 @@ export class FakeAudioEncoder {
 
 		queueMicrotask(() => {
 			this.#encodeQueueSize--;
+			this.dispatchEvent(new Event("dequeue"));
 			const chunk = {
 				type: "key" as EncodedAudioChunkType,
 				timestamp: data.timestamp,


### PR DESCRIPTION
## What

`AudioEncodeNode.#next` cloned every stream-sourced `AudioData` before encoding (`value.clone()` + close original + encode clone + close clone). But the node **owns these frames outright** — the `ReadableStream` is created in the constructor and the `AudioData` is constructed there from worklet messages. The clone was redundant.

**Provably safe:** the existing code already did `encode(clonedData); clonedData.close()` — i.e. it closes immediately after `encode()` returns, which is only correct because WebCodecs `encode()` captures the frame synchronously. By the same reasoning, closing the original `value` right after `encode()` is equally safe; the clone gave no safety benefit even before. (`process()` still clones, correctly, because the **caller** owns that frame.)

## Measurement

Harness: `packages/av_nodes/audio/encode_bench.ts` (kept as a regression guard). Drives the real worklet-port → `ReadableStream` → `#next` path, N=20000 frames, GC controlled via `--v8-flags=--expose-gc`, median of middle 12 of 20 runs.

| | elapsed (ms) | fps |
| --- | --- | --- |
| baseline | ~24.5 | ~815k |
| optimized | ~18.5 | ~1.08M |
| **delta** | **~25%** | |

⚠️ **GC control was essential.** The win is mostly GC pressure: the clone allocated a short-lived `FakeAudioData` per frame, and without forced GC the per-frame signal was buried in GC-scheduling noise — run-to-run swung 20–34 ms (which is why an initial naive measurement looked like an unreliable "40%" then collapsed to "no signal"). With `gc()` before each run, variance drops to <1% on both sides and the ~25% delta is stable and reproduced.

## Caveat (lab ≠ production)

`FakeAudioData.clone()` allocates a real object, so the cost is measured (unlike video). At realistic audio frame rates (~50 fps for 20 ms chunks) the absolute saving is small; the change is most visible under sustained high frame rates. Real-world impact must be confirmed in a browser.

## Verification
- `deno check` clean
- `packages/av_nodes/audio` suite: **45 passed / 0 failed** (the `process()`-path clone test still passes — only `#next` changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)