### PR TITLE
test: force-install OffscreenCanvas/idle fakes so analyser tests run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 
 - Fix infinite loop in `VideoDecodeNode` and `AudioDecodeNode` backpressure handling — replace busy `queueMicrotask` spin with event-driven `dequeue` listener and a 5-second timeout fallback ([#5]).
 - Fix infinite loop in `AudioEncodeNode` encoder backpressure — wait for the encoder `dequeue` event (with a 5-second timeout) instead of busy-spinning via `queueMicrotask`, and stop reading the stream when the drain times out ([#12]).
+- Fix failing `VideoAnalyserNode` test block — force-install the `OffscreenCanvas`/`requestIdleCallback` test doubles regardless of native presence, since Deno's native `OffscreenCanvas.getContext("2d")` returns null headlessly ([#16]).
 
 ### Changed
 
@@ -78,3 +79,4 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 [#12]: https://github.com/okdaichi/moqrtc-js/pull/12
 [#14]: https://github.com/okdaichi/moqrtc-js/pull/14
 [#15]: https://github.com/okdaichi/moqrtc-js/pull/15
+[#16]: https://github.com/okdaichi/moqrtc-js/pull/16

--- a/packages/av_nodes/video/fake_offscreen_canvas_test.ts
+++ b/packages/av_nodes/video/fake_offscreen_canvas_test.ts
@@ -24,9 +24,11 @@ export function overrideOffscreenCanvas() {
 	const hasOffscreenCanvas = Object.prototype.hasOwnProperty.call(g, "OffscreenCanvas");
 	const originalOffscreenCanvas = g.OffscreenCanvas;
 
-	if (typeof OffscreenCanvas === "undefined") {
-		g.OffscreenCanvas = FakeOffscreenCanvas as unknown;
-	}
+	// Always install the fake. Deno ships a native OffscreenCanvas, but its 2D
+	// context returns null in a headless process, which would silently break any
+	// code (e.g. VideoAnalyserNode) that calls getContext("2d"). The fake is the
+	// only one that actually renders here.
+	g.OffscreenCanvas = FakeOffscreenCanvas as unknown;
 
 	return () => {
 		if (hasOffscreenCanvas) {
@@ -44,20 +46,19 @@ export function overrideIdleCallback() {
 	const hasCancelIdleCallback = Object.prototype.hasOwnProperty.call(g, "cancelIdleCallback");
 	const originalCancelIdleCallback = g.cancelIdleCallback;
 
-	if (typeof requestIdleCallback === "undefined") {
-		(g as unknown as { requestIdleCallback: unknown }).requestIdleCallback = (
-			callback: () => void,
-		) => {
-			setTimeout(callback, 1);
-			return 1;
-		};
-	}
+	// Always install the fake. A native requestIdleCallback (if present) only
+	// fires during browser idle time, which never arrives in a test, so the
+	// deferred work would never run.
+	(g as unknown as { requestIdleCallback: unknown }).requestIdleCallback = (
+		callback: () => void,
+	) => {
+		setTimeout(callback, 1);
+		return 1;
+	};
 
-	if (typeof cancelIdleCallback === "undefined") {
-		(g as unknown as { cancelIdleCallback: unknown }).cancelIdleCallback = (_id: number) => {
-			clearTimeout(_id);
-		};
-	}
+	(g as unknown as { cancelIdleCallback: unknown }).cancelIdleCallback = (_id: number) => {
+		clearTimeout(_id);
+	};
 
 	return () => {
 		if (hasRequestIdleCallback) {


### PR DESCRIPTION
## Problem

The entire `VideoAnalyserNode` test block was **failing** (`assertExists` on a null `analysis`). This is the pre-existing red test that's been showing up as `1 failed` in the `av_nodes` suite.

## Root cause

`overrideOffscreenCanvas()` only installed the fake when `typeof OffscreenCanvas === "undefined"`:

```ts
if (typeof OffscreenCanvas === "undefined") {
  g.OffscreenCanvas = FakeOffscreenCanvas as unknown;
}
```

That guard was written when Deno lacked `OffscreenCanvas`. **Deno now ships a native `OffscreenCanvas`** — but its `getContext("2d")` returns `null` in a headless process:

```
$ deno eval 'console.log(new OffscreenCanvas(160,120).getContext("2d"))'
null
```

So the guard skipped the fake → the analyser used the native canvas → `this.#ctx = null` → `if (!this.#ctx) return;` (analyse_node.ts) → `#currentAnalysis` stayed `null` → every analysis assertion failed. The failure was silent (caught/early-returned), which is why it presented as a missing-analysis assertion rather than a thrown error.

## Fix

Always install both fakes regardless of native presence:
- **`OffscreenCanvas`** — the native one can't render here, so the fake is the only usable implementation in tests.
- **`requestIdleCallback`** — a native one only fires during real browser idle time, which never arrives in a test, so deferred work would never run. (Currently benign — Deno lacks it — but the same trap if/when Deno adds it.)

The restore paths already handle both the had-it and didn't-have-it cases, so this is safe and deterministic across Deno versions.

## Verification

| | before | after |
| --- | --- | --- |
| `av_nodes` suite | 58 passed / **1 failed** | **59 passed / 0 failed** |
| `VideoAnalyserNode` block | failed (all analysis steps) | 18 steps pass |

`deno lint` + `deno fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)