### PR TITLE
fix(av_nodes): keep benches/tests out of publish; gate encode_bench runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 - Fix infinite loop in `VideoDecodeNode` and `AudioDecodeNode` backpressure handling — replace busy `queueMicrotask` spin with event-driven `dequeue` listener and a 5-second timeout fallback ([#5]).
 - Fix infinite loop in `AudioEncodeNode` encoder backpressure — wait for the encoder `dequeue` event (with a 5-second timeout) instead of busy-spinning via `queueMicrotask`, and stop reading the stream when the drain times out ([#12]).
 - Fix failing `VideoAnalyserNode` test block — force-install the `OffscreenCanvas`/`requestIdleCallback` test doubles regardless of native presence, since Deno's native `OffscreenCanvas.getContext("2d")` returns null headlessly ([#16]).
+- Fix `@okdaichi/av-nodes` publish graph: benchmark harnesses (and, due to a root-only glob, ~20 test/fake files) were being published to jsr. Gate `encode_bench.ts`'s runner behind `import.meta.main` and exclude `**/*_bench.ts` / `**/*_test.ts` from `publish.exclude` ([#17]).
 
 ### Changed
 
@@ -80,3 +81,4 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 [#14]: https://github.com/okdaichi/moqrtc-js/pull/14
 [#15]: https://github.com/okdaichi/moqrtc-js/pull/15
 [#16]: https://github.com/okdaichi/moqrtc-js/pull/16
+[#17]: https://github.com/okdaichi/moqrtc-js/pull/17

--- a/packages/av_nodes/audio/encode_bench.ts
+++ b/packages/av_nodes/audio/encode_bench.ts
@@ -132,24 +132,44 @@ async function runEncode(n: number): Promise<number> {
 	return elapsedMs;
 }
 
-const runs: number[] = [];
-// Force GC before each run if available (--v8-flags=--expose-gc) so the
-// comparison reflects steady-state allocation cost rather than GC scheduling
-// luck. Without this, run-to-run variance dwarfs the per-frame signal.
-const gc = (globalThis as unknown as { gc?: () => void }).gc?.bind(globalThis);
-for (let i = 0; i < 20; i++) {
-	gc?.();
-	runs.push(await runEncode(N));
+// `deno bench` entrypoint: a single run for regression detection.
+Deno.bench({
+	name: "audio encode #next throughput (20000 frames)",
+	group: "audio-encode",
+	baseline: true,
+	async fn() {
+		await runEncode(N);
+	},
+});
+
+// Standalone runner for a GC-controlled multi-run median. Run with:
+//   deno run --v8-flags=--expose-gc --allow-all packages/av_nodes/audio/encode_bench.ts
+// Gated by import.meta.main so that `deno bench` (or any import) does not also
+// execute this 20x20k-frame loop on module load.
+if (import.meta.main) {
+	const runs: number[] = [];
+	// Force GC before each run if available (--v8-flags=--expose-gc) so the
+	// comparison reflects steady-state allocation cost rather than GC scheduling
+	// luck. Without this, run-to-run variance dwarfs the per-frame signal.
+	const gc = (globalThis as unknown as { gc?: () => void }).gc?.bind(
+		globalThis,
+	);
+	for (let i = 0; i < 20; i++) {
+		gc?.();
+		runs.push(await runEncode(N));
+	}
+	runs.sort((a, b) => a - b);
+	// discard warmup tails, report median + trimmed mean of the middle 12
+	const mid = runs.slice(4, 16);
+	const median = mid[Math.floor(mid.length / 2)] ?? 0;
+	const mean = mid.reduce((s, r) => s + r, 0) / mid.length;
+	console.log(
+		`audio encode #next: N=${N} frames, 20 runs (middle 12 used)`,
+	);
+	console.log(
+		`elapsed ms: median ${median.toFixed(2)} mean ${mean.toFixed(2)} | fps median ${
+			(N / (median / 1000)).toFixed(0)
+		}`,
+	);
+	console.log(`all runs (ms): ${runs.map((r) => r.toFixed(0)).join(", ")}`);
 }
-runs.sort((a, b) => a - b);
-// discard warmup tails, report median + trimmed mean of the middle 12
-const mid = runs.slice(4, 16);
-const median = mid[Math.floor(mid.length / 2)] ?? 0;
-const mean = mid.reduce((s, r) => s + r, 0) / mid.length;
-console.log(
-	`audio encode #next: N=${N} frames, 20 runs (middle 12 used)`,
-);
-console.log(
-	`elapsed ms: median ${median.toFixed(2)} mean ${mean.toFixed(2)} | fps median ${(N / (median / 1000)).toFixed(0)}`,
-);
-console.log(`all runs (ms): ${runs.map((r) => r.toFixed(0)).join(", ")}`);

--- a/packages/av_nodes/deno.json
+++ b/packages/av_nodes/deno.json
@@ -1,71 +1,72 @@
 {
-  "name": "@okdaichi/av-nodes",
-  "version": "0.10.1",
-  "exports": {
-    ".": "./mod.ts"
-  },
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/okdaichi/moqrtc-js",
-    "directory": "packages/av_nodes"
-  },
-  "description": "WebCodecs-based video and audio processing nodes with MoQ Transport support",
-  "keywords": [
-    "webcodecs",
-    "video",
-    "audio",
-    "encoding",
-    "decoding",
-    "moq",
-    "streaming",
-    "webrtc"
-  ],
-  "compilerOptions": {
-    "lib": ["ESNext", "deno.ns", "DOM", "dom.iterable", "dom.asynciterable"],
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "noUncheckedIndexedAccess": true
-  },
-  "tasks": {
-    "build:worklets": "deno run -A scripts/build_worklets.ts",
-    "check": "deno check **/*.ts",
-    "test": "deno test --allow-all",
-    "publish": "deno task build:worklets && deno publish"
-  },
-  "fmt": {
-    "useTabs": true,
-    "lineWidth": 100,
-    "indentWidth": 4,
-    "singleQuote": false,
-    "semiColons": true
-  },
-  "lint": {
-    "rules": {
-      "tags": ["recommended"],
-      "exclude": ["require-await"]
-    }
-  },
-  "exclude": [
-    "demo/",
-    "*_test.ts",
-    "mock_*.ts",
-    "audio/audio_hijack_worklet.ts",
-    "audio/audio_offload_worklet.ts"
-  ],
-  "publish": {
-    "exclude": [
-      "demo/",
-      "*_test.ts",
-      "mock_*.ts",
-      "scripts/",
-      "audio/audio_hijack_worklet.ts",
-      "audio/audio_offload_worklet.ts"
-    ]
-  },
-  "imports": {
-    "@okdaichi/golikejs": "jsr:@okdaichi/golikejs@0.9.0",
-    "@std/assert": "jsr:@std/assert@^1.0.16"
-  }
+	"name": "@okdaichi/av-nodes",
+	"version": "0.10.1",
+	"exports": {
+		".": "./mod.ts"
+	},
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/okdaichi/moqrtc-js",
+		"directory": "packages/av_nodes"
+	},
+	"description": "WebCodecs-based video and audio processing nodes with MoQ Transport support",
+	"keywords": [
+		"webcodecs",
+		"video",
+		"audio",
+		"encoding",
+		"decoding",
+		"moq",
+		"streaming",
+		"webrtc"
+	],
+	"compilerOptions": {
+		"lib": ["ESNext", "deno.ns", "DOM", "dom.iterable", "dom.asynciterable"],
+		"strict": true,
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"noUncheckedIndexedAccess": true
+	},
+	"tasks": {
+		"build:worklets": "deno run -A scripts/build_worklets.ts",
+		"check": "deno check **/*.ts",
+		"test": "deno test --allow-all",
+		"publish": "deno task build:worklets && deno publish"
+	},
+	"fmt": {
+		"useTabs": true,
+		"lineWidth": 100,
+		"indentWidth": 4,
+		"singleQuote": false,
+		"semiColons": true
+	},
+	"lint": {
+		"rules": {
+			"tags": ["recommended"],
+			"exclude": ["require-await"]
+		}
+	},
+	"exclude": [
+		"demo/",
+		"*_test.ts",
+		"mock_*.ts",
+		"audio/audio_hijack_worklet.ts",
+		"audio/audio_offload_worklet.ts"
+	],
+	"publish": {
+		"exclude": [
+			"demo/",
+			"**/*_test.ts",
+			"**/*_bench.ts",
+			"mock_*.ts",
+			"scripts/",
+			"audio/audio_hijack_worklet.ts",
+			"audio/audio_offload_worklet.ts"
+		]
+	},
+	"imports": {
+		"@okdaichi/golikejs": "jsr:@okdaichi/golikejs@0.9.0",
+		"@std/assert": "jsr:@std/assert@^1.0.16"
+	}
 }


### PR DESCRIPTION
## Problem

Two issues with the bench files added in #14/#15, found during PR review:

1. **`encode_bench.ts` ran its 20 × 20000-frame loop on every module load** (not `import.meta.main`-gated, no `Deno.bench`). So `deno bench` (or any import) executed the whole loop, corrupting bench output and slowing every run. `decode_bench.ts` was already gated correctly.

2. **Benchmark harnesses shipped to jsr.** No exclude pattern matched `*_bench.ts`. The same broken-glob problem applied to `*_test.ts`: the pattern only matches the package root, so ~20 `audio/`/`video/` test files and fakes were being published too. Verified empirically — `deno publish --dry-run` on `main` lists 30 bench/test lines in the publish graph.

## Fix

- Gate `encode_bench.ts`'s runner behind `if (import.meta.main)` and add a single-run `Deno.bench` entry, mirroring `decode_bench.ts`.
- Add `**/*_bench.ts` and change `*_test.ts` → `**/*_test.ts` **in `publish.exclude` only**. The top-level `exclude` is left untouched because it drives `deno test` discovery — widening it to `**/*_test.ts` there would silently stop every test from running.

Verified no published source imports a `*_test.ts` (so excluding them can't break the graph), then confirmed with `deno publish --dry-run`:
- publish graph drops from ~50 files to **23 source-only files** (0 bench/test)
- `Success Dry run complete`, no broken refs

## Verification
- `deno bench encode_bench.ts` → single clean bench (~52 ms), no 20× loop
- `deno test packages/av_nodes/` → **60 passed / 0 failed** (subdir tests still discovered)
- `deno lint` + `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)