### PR TITLE
fix(av-nodes): close video frames on throw and fix polyfill frame pacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 
 ### Fixed
 
+- Close `VideoFrame`s on throw across the video pipeline (`VideoOverlayNode`, `VideoDestinationNode`, `VideoSourceNode`) so a throwing overlay function, `drawImage`, or `VideoFrame` constructor can no longer leak a GPU-backed frame; and stop the `MediaStreamVideoSourceNode` polyfill from pacing frames twice (it delivered ~half the configured frame rate because both the source loop and the stream `pull()` awaited the next frame).
 - Fix infinite loop in `VideoDecodeNode` and `AudioDecodeNode` backpressure handling — replace busy `queueMicrotask` spin with event-driven `dequeue` listener and a 5-second timeout fallback ([#5]).
 - Fix infinite loop in `AudioEncodeNode` encoder backpressure — wait for the encoder `dequeue` event (with a 5-second timeout) instead of busy-spinning via `queueMicrotask`, and stop reading the stream when the drain times out ([#12]).
 - Fix failing `VideoAnalyserNode` test block — force-install the `OffscreenCanvas`/`requestIdleCallback` test doubles regardless of native presence, since Deno's native `OffscreenCanvas.getContext("2d")` returns null headlessly ([#16]).

--- a/packages/av_nodes/video/destination_node.ts
+++ b/packages/av_nodes/video/destination_node.ts
@@ -157,15 +157,18 @@ export class VideoDestinationNode extends VideoNode {
 			return;
 		}
 
-		// Clear the canvas and draw frame
-		ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-		ctx.drawImage(frame, x, y, width, height);
-
-		// Close the frame after rendering
+		// Clear the canvas and draw frame. try/finally guarantees the frame is
+		// closed even if drawImage throws (e.g. zero-size geometry) — otherwise
+		// the frame leaks and the rejection propagates unhandled.
 		try {
-			frame.close();
-		} catch (e) {
-			console.error("[VideoDestinationNode] frame close error:", e);
+			ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+			ctx.drawImage(frame, x, y, width, height);
+		} finally {
+			try {
+				frame.close();
+			} catch (e) {
+				console.error("[VideoDestinationNode] frame close error:", e);
+			}
 		}
 	}
 

--- a/packages/av_nodes/video/overlay_node.ts
+++ b/packages/av_nodes/video/overlay_node.ts
@@ -39,23 +39,19 @@ export class VideoOverlayNode extends VideoNode {
 
 		const clonedFrame = input.clone();
 
-		if (!this.#ctx) {
-			// No context; pass through unchanged
-			for (const output of Array.from(this.outputs)) {
-				try {
-					output.process(clonedFrame);
-				} catch (e) {
-					console.error("[VideoOverlayNode] process error:", e);
+		try {
+			if (!this.#ctx) {
+				// No context; pass through unchanged
+				for (const output of Array.from(this.outputs)) {
+					try {
+						output.process(clonedFrame);
+					} catch (e) {
+						console.error("[VideoOverlayNode] process error:", e);
+					}
 				}
+				return;
 			}
 
-			// Close the input frame (we own it)
-			clonedFrame.close();
-
-			return;
-		}
-
-		try {
 			const width = clonedFrame.displayWidth;
 			const height = clonedFrame.displayHeight;
 
@@ -80,9 +76,6 @@ export class VideoOverlayNode extends VideoNode {
 				duration: clonedFrame.duration ?? undefined,
 			});
 
-			// Close the input frame (we own it)
-			clonedFrame.close();
-
 			// Pass cloned frames to outputs (we own outputFrame)
 			for (const output of Array.from(this.outputs)) {
 				try {
@@ -106,6 +99,14 @@ export class VideoOverlayNode extends VideoNode {
 			outputFrame.close();
 		} catch (e) {
 			console.error("[VideoOverlayNode] overlay composition error:", e);
+		} finally {
+			// We own clonedFrame; close it on every path (success, throw, and
+			// no-ctx passthrough) so a throwing overlay/drawImage can't leak it.
+			try {
+				clonedFrame.close();
+			} catch (_) {
+				/* ignore double-close */
+			}
 		}
 	}
 }

--- a/packages/av_nodes/video/source_node.ts
+++ b/packages/av_nodes/video/source_node.ts
@@ -64,17 +64,23 @@ export class VideoSourceNode extends VideoNode {
 					const { done, value: frame } = await this.#reader.read();
 					if (done) break;
 
-					// Create new frame with context's timestamp (single source of truth)
-					const retimedFrame = new VideoFrame(frame, {
-						timestamp, // Use context's μs timestamp
-					});
-					frame.close(); // Close original frame
+					try {
+						// Create new frame with context's timestamp (single source of truth)
+						const retimedFrame = new VideoFrame(frame, {
+							timestamp, // Use context's μs timestamp
+						});
 
-					// Pass retimedFrame to outputs (they will clone if needed)
-					this.process(retimedFrame);
+						// Pass retimedFrame to outputs (they will clone if needed)
+						this.process(retimedFrame);
 
-					// Ownership: We own the retimedFrame, so we close it
-					retimedFrame.close();
+						// Ownership: We own the retimedFrame, so we close it
+						retimedFrame.close();
+					} finally {
+						// Close the original frame on every path — if the VideoFrame
+						// constructor throws (unsupported format / closed source
+						// frame) it would otherwise leak.
+						frame.close();
+					}
 				}
 			} catch (e) {
 				// Ignore expected errors during shutdown
@@ -154,12 +160,13 @@ export class MediaStreamVideoSourceNode extends VideoSourceNode {
 					]);
 				},
 				async pull(controller) {
-					// Use context's frame pacing - single source of truth for timing
-					const timestamp = await context._waitNextFrame();
-
+					// Frame pacing is owned by VideoSourceNode.start(), which awaits
+					// context._waitNextFrame() before each read(). Pacing again here
+					// doubles the interval (a 30fps context delivered ~15fps), so
+					// just enqueue at the current context timestamp.
 					controller.enqueue(
 						new VideoFrame(video, {
-							timestamp, // μs from context
+							timestamp: context.currentTimestamp, // μs from context
 						}),
 					);
 				},


### PR DESCRIPTION
Closes VideoFrame leaks across the video pipeline and fixes half-rate frame delivery in the MediaStreamTrack polyfill.

- **VideoOverlayNode**: wrap composition in try/finally so clonedFrame is closed even when the overlay fn / drawImage / VideoFrame ctor throws.
- **VideoDestinationNode**: wrap drawImage+close in try/finally so a throwing drawImage can't leak the pending frame or reject unhandled.
- **VideoSourceNode**: close the original frame in finally around the retime constructor; and stop the MediaStreamTrack polyfill from pacing frames twice (pull() awaited _waitNextFrame() while start() already did).

🤖 Generated with [Claude Code](https://claude.com/claude-code)