### PR TITLE
fix(av-nodes): close frames on throw and cancel streams on dispose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 
 ### Fixed
 
+- Close decoded audio frames even when processing throws, and cancel in-flight decode/encode stream reads on `dispose()` in `AudioDecodeNode`/`VideoDecodeNode`/`AudioEncodeNode` so tearing down a node mid-stream no longer leaks the reader lock, buffers upstream into a dead pipe, or hangs the internal encode loop.
 - Fix infinite loop in `VideoDecodeNode` and `AudioDecodeNode` backpressure handling — replace busy `queueMicrotask` spin with event-driven `dequeue` listener and a 5-second timeout fallback ([#5]).
 - Fix infinite loop in `AudioEncodeNode` encoder backpressure — wait for the encoder `dequeue` event (with a 5-second timeout) instead of busy-spinning via `queueMicrotask`, and stop reading the stream when the drain times out ([#12]).
 - Fix failing `VideoAnalyserNode` test block — force-install the `OffscreenCanvas`/`requestIdleCallback` test doubles regardless of native presence, since Deno's native `OffscreenCanvas.getContext("2d")` returns null headlessly ([#16]).

--- a/packages/av_nodes/audio/decode_node.ts
+++ b/packages/av_nodes/audio/decode_node.ts
@@ -35,6 +35,10 @@ export class AudioDecodeNode extends GainNode {
 	// allocating a `.then()` continuation on every decoded frame.
 	#worklet: AudioWorkletNode | null = null;
 	#disposed = false;
+	// Active decodeFrom reader, retained so dispose() can cancel an in-flight
+	// read() instead of leaving it pending (and upstream buffering into a pipe
+	// nobody drains).
+	#activeReader?: ReadableStreamDefaultReader<EncodedAudioChunk>;
 
 	// Callback for decoded output (for metrics)
 	onoutput: (() => void) | null = null;
@@ -80,11 +84,16 @@ export class AudioDecodeNode extends GainNode {
 
 		this.#decoder = new AudioDecoder({
 			output: (frame) => {
-				// Pass audio frame to processing
-				this.#process(frame);
-
-				// Close the decoded frame after processing
-				frame.close();
+				// try/finally guarantees the frame is closed even if #process
+				// throws (e.g. copyTo format mismatch) — otherwise every decoded
+				// AudioData would leak and the throw would escape the callback.
+				try {
+					this.#process(frame);
+				} catch (e) {
+					console.error("[AudioDecodeNode] process error:", e);
+				} finally {
+					frame.close();
+				}
 			},
 			error: (e) => {
 				console.error("[AudioDecodeNode] decoder error:", e);
@@ -119,6 +128,7 @@ export class AudioDecodeNode extends GainNode {
 				| undefined;
 			try {
 				reader = stream.getReader();
+				this.#activeReader = reader;
 				while (this.context.state === "running" && !this.#disposed) {
 					// Backpressure: Wait for decoder queue to drain before reading
 					// from upstream so the stream can naturally slow down.
@@ -156,6 +166,7 @@ export class AudioDecodeNode extends GainNode {
 					console.error("[AudioDecodeNode] decodeFrom error:", e);
 				}
 			} finally {
+				this.#activeReader = undefined;
 				reader?.releaseLock();
 			}
 		})();
@@ -285,6 +296,14 @@ export class AudioDecodeNode extends GainNode {
 		// Close decoder directly (skip flush to avoid AbortError)
 		try {
 			this.#decoder.close();
+		} catch (_) {
+			/* ignore */
+		}
+
+		// Cancel any in-flight decodeFrom read() so its loop unblocks instead
+		// of staying pending on a stream we no longer drain.
+		try {
+			void this.#activeReader?.cancel();
 		} catch (_) {
 			/* ignore */
 		}

--- a/packages/av_nodes/audio/encode_node.ts
+++ b/packages/av_nodes/audio/encode_node.ts
@@ -35,6 +35,10 @@ export class AudioEncodeNode extends GainNode {
 	#workletReady: Promise<AudioWorkletNode>;
 	#disposed = false;
 	#dests: Map<AudioEncodeDestination, CancelFunc> = new Map();
+	// Retained to tear down on dispose: closing the controller unblocks #next's
+	// pending read(); closing the port detaches the onmessage that feeds it.
+	#readableController?: ReadableStreamDefaultController<AudioData>;
+	#worklet: AudioWorkletNode | null = null;
 
 	constructor(context: AudioContextLike) {
 		// Initialize as a passthrough GainNode
@@ -80,6 +84,7 @@ export class AudioEncodeNode extends GainNode {
 
 				const readable = new ReadableStream<AudioData>({
 					start: (controller) => {
+						this.#readableController = controller;
 						worklet.port.onmessage = (
 							{ data }: { data: AudioDataInit },
 						) => {
@@ -103,6 +108,7 @@ export class AudioEncodeNode extends GainNode {
 				// This captures all audio flowing into this node
 				super.connect(worklet);
 
+				this.#worklet = worklet;
 				this.#next(readable.getReader());
 				return worklet;
 			},
@@ -309,6 +315,21 @@ export class AudioEncodeNode extends GainNode {
 		// Disconnect this GainNode
 		try {
 			super.disconnect();
+		} catch (_) {
+			/* ignore */
+		}
+
+		// Close the internal worklet→encoder stream so #next's pending read()
+		// unblocks (it only re-checks #disposed after read returns), and detach
+		// the onmessage handler so late worklet messages don't enqueue into a
+		// dead stream.
+		try {
+			this.#readableController?.close();
+		} catch (_) {
+			/* ignore */
+		}
+		try {
+			this.#worklet?.port.close();
 		} catch (_) {
 			/* ignore */
 		}

--- a/packages/av_nodes/video/decode_node.ts
+++ b/packages/av_nodes/video/decode_node.ts
@@ -6,6 +6,9 @@ const MAX_QUEUE_SIZE = 3;
 export class VideoDecodeNode extends VideoNode {
 	readonly context: VideoContext;
 	#decoder: VideoDecoder;
+	// Active decodeFrom reader, retained so dispose() can cancel an in-flight
+	// read() instead of leaving it pending.
+	#activeReader?: ReadableStreamDefaultReader<EncodedVideoChunk>;
 
 	constructor(context: VideoContext) {
 		super({ numberOfInputs: 1, numberOfOutputs: 1 });
@@ -55,6 +58,7 @@ export class VideoDecodeNode extends VideoNode {
 				| undefined;
 			try {
 				reader = stream.getReader();
+				this.#activeReader = reader;
 				while (this.context.state === "running" && !this.disposed) {
 					// Backpressure: Wait for decoder queue to drain before reading
 					// from upstream so the stream can naturally slow down.
@@ -90,6 +94,7 @@ export class VideoDecodeNode extends VideoNode {
 			} catch (e) {
 				console.error("[VideoDecodeNode] decodeFrom error:", e);
 			} finally {
+				this.#activeReader = undefined;
 				reader?.releaseLock();
 			}
 		})();
@@ -165,6 +170,12 @@ export class VideoDecodeNode extends VideoNode {
 
 	override async dispose(): Promise<void> {
 		if (this.disposed) return;
+		// Cancel any in-flight decodeFrom read() first so its loop unblocks.
+		try {
+			await this.#activeReader?.cancel();
+		} catch (_) {
+			/* ignore */
+		}
 		try {
 			await this.flush();
 		} catch (_) {


### PR DESCRIPTION
Three resource-lifecycle fixes across the codec nodes so tearing down a node mid-stream no longer leaks or hangs.

- **AudioDecodeNode**: wrap the decoder output callback in try/finally so the decoded `AudioData` is closed even if `#process` throws (was leaking one frame per decoded frame + the throw would escape the callback).
- **AudioDecodeNode / VideoDecodeNode**: retain the `decodeFrom` reader and `cancel()` it in `dispose()` so an in-flight `read()` unblocks instead of hanging and leaking the reader lock / buffering upstream into a dead pipe.
- **AudioEncodeNode**: cache the internal `ReadableStream` controller and the worklet, and close both on `dispose()` so `#next`'s pending `read()` unblocks and the `onmessage` handler is detached from a dead stream.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)