### PR TITLE
🧪 test: Add test for MediaDeviceContext.getStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 
 ### Added
 
+- Add unit test coverage for `MediaDeviceContext.getStats()`.
 - Migrate the repository to the Deno runtime: add `deno.json` and `deno.lock`, convert tests to `Deno.test`, and update CI workflows and VSCode tasks.
 - Add AV nodes package and media processing building blocks under `src/internal/av_nodes/` (audio/video encode & decode nodes, worklets, demo, build scripts and Deno tests).
 - Add test helpers and headless fakes to support Deno testing (`test_globals.d.ts`, `stubGlobal`, `deleteGlobal`, fake encoders/frames/framesources).

--- a/src/media/device_test.ts
+++ b/src/media/device_test.ts
@@ -43,6 +43,36 @@ Deno.test("MediaDeviceContext", async (t) => {
 		assertEquals(device.deviceId, "cam-1");
 	});
 
+	await t.step("getStats returns correct aggregated state", async () => {
+		using _fakeMap = setupFakeMediaDevices(devices);
+		const context = new MediaDeviceContext();
+		await context.updateDevices();
+
+		let stats = context.getStats();
+		assertEquals(stats, {
+			audioDevices: 1,
+			videoDevices: 1,
+			hasAudioPermission: false,
+			hasVideoPermission: false,
+			activeListeners: 0,
+		});
+
+		await context.requestPermission("video");
+		const unsubscribe = context.subscribe(() => {});
+		await context.updateDevices();
+
+		stats = context.getStats();
+		assertEquals(stats, {
+			audioDevices: 1,
+			videoDevices: 1,
+			hasAudioPermission: false,
+			hasVideoPermission: true,
+			activeListeners: 1,
+		});
+
+		unsubscribe();
+	});
+
 	await t.step("subscribe/unsubscribe and trigger devicechange", async () => {
 		using _fakeMap = setupFakeMediaDevices(devices);
 		const context = new MediaDeviceContext();


### PR DESCRIPTION
🎯 **What:** Added a missing test for `MediaDeviceContext.getStats`.
📊 **Coverage:** The test covers the happy paths of the `getStats` method, asserting the initial object properties and correctly verifying updates after requesting permissions and adding a subscriber.
✨ **Result:** Improved overall test coverage for the media device utilities in `src/media/device.ts` and ensure correct behavior of stats aggregation.

---
*PR created automatically by Jules for task [1592566710310107835](https://jules.google.com/task/1592566710310107835) started by @okdaichi*