### PR TITLE
🧪 Add test for RoomElement onleave handler failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 
 ### Fixed
 
+- Add test for `RoomElement.onleave` handler failure to ensure it correctly transitions the room status to `error`.
 - `VideoAnalyserNode`: report `frameIndex` as the cumulative *input* frame count (it previously counted only analyzed frames, so with `analysisInterval > 1` it understated the true frame number); validate `analysisSize` / `historySize` / `analysisInterval` (0 or non-integer values previously produced `NaN` metrics or silently disabled analysis; `analysisSize` is also capped at 4096 per side to prevent a multi-hundred-MB allocation from an oversized value).
 - `videoEncoderConfig` now validates `width` / `height` / `frameRate` (negative or non-finite values previously produced a negative computed bitrate forwarded to the encoder) and treats an explicit `bitrate` of `0` or negative as "not set", falling back to the calculated bitrate instead of configuring the encoder with bitrate 0.
 - Close `VideoFrame`s on throw across the video pipeline (`VideoOverlayNode`, `VideoDestinationNode`, `VideoSourceNode`) so a throwing overlay function, `drawImage`, or `VideoFrame` constructor can no longer leak a GPU-backed frame; and stop the `MediaStreamVideoSourceNode` polyfill from pacing frames twice (it delivered ~half the configured frame rate because both the source loop and the stream `pull()` awaited the next frame).

--- a/src/elements/room_test.ts
+++ b/src/elements/room_test.ts
@@ -362,6 +362,42 @@ Deno.test("RoomElement - onjoin callback fires when member joins", async () => {
 	}
 });
 
+Deno.test("RoomElement - onleave handler failure reports error status", async () => {
+	const { restoreDOM, element } = await createRoomElementFixture();
+	try {
+		element.setAttribute("room-id", "test-room");
+
+		let statusCalled = false;
+		let statusArg: RoomLifecycleStatus | undefined;
+		element.onstatus = (status) => {
+			if (status.type === "error") {
+				statusCalled = true;
+				statusArg = status;
+			}
+		};
+
+		element.onleave = () => {
+			throw new Error("test error");
+		};
+
+		await element.join(
+			createFakeSession("test-room", "test-publisher", {
+				includeRemote: true,
+			}) as unknown as Session,
+			{ name: "test-publisher", serveTrack: () => {} },
+		);
+		await Promise.resolve();
+		element.room?.disconnect();
+
+		assert(statusCalled);
+		assertExists(statusArg);
+		assertEquals(statusArg.type, "error");
+		assert(statusArg.message.includes("onleave handler failed: test error"));
+	} finally {
+		restoreDOM();
+	}
+});
+
 Deno.test("RoomElement - onleave callback fires when member leaves", async () => {
 	const { restoreDOM, element } = await createRoomElementFixture();
 	try {


### PR DESCRIPTION
🎯 **What:** The testing gap where `RoomElement.onleave` handler failures were not tested for correctly updating the status to an error has been addressed.
📊 **Coverage:** Added test `"RoomElement - onleave handler failure reports error status"` which covers the scenario where an exception is thrown in the `onleave` callback.
✨ **Result:** Improved test coverage and reliability for `RoomElement` lifecycle hooks handling.

---
*PR created automatically by Jules for task [4888236490515820961](https://jules.google.com/task/4888236490515820961) started by @okdaichi*