### PR TITLE
🧹 Remove commented out code `localName` in room.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This branch contains a large migration to the Deno runtime and a refactor of the AV/media and Room/elements APIs. For the full diff see the [compare view][Unreleased]. Related pull request: [#3].
 
+### Changed
+- Remove commented out dead code `localName` in `src/elements/room.ts` to improve code health.
+
 ### Added
 
 - Migrate the repository to the Deno runtime: add `deno.json` and `deno.lock`, convert tests to `Deno.test`, and update CI workflows and VSCode tasks.

--- a/src/elements/room.ts
+++ b/src/elements/room.ts
@@ -56,7 +56,6 @@ export class RoomElement extends HTMLElement {
 	// Public methods
 	async join(session: Session, local: LocalBroadcast): Promise<void> {
 		const roomId = this.getAttribute("room-id");
-		// const localName = this.getAttribute('local-name');
 		const description = this.getAttribute("description");
 
 		if (!roomId) {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the commented out code `const localName` from `src/elements/room.ts`.

💡 **Why:** How this improves maintainability
The commented-out line is dead code that doesn't contribute to the file. Removing it cleans up the source code and prevents future confusion.

✅ **Verification:** How you confirmed the change is safe
Ran `deno test`, `deno lint` and `deno fmt` and verified there are no errors. Also, as this was commented-out code, it doesn't affect functionality.

✨ **Result:** The improvement achieved
A cleaner source file with no unnecessary dead code comments.

---
*PR created automatically by Jules for task [13991636161326381604](https://jules.google.com/task/13991636161326381604) started by @okdaichi*