### PR TITLE
🧪 test(media): add test for Microphone.switchDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 
 ### Added
 
+- Add missing test for `Microphone.switchDevice`.
 - Migrate the repository to the Deno runtime: add `deno.json` and `deno.lock`, convert tests to `Deno.test`, and update CI workflows and VSCode tasks.
 - Add AV nodes package and media processing building blocks under `src/internal/av_nodes/` (audio/video encode & decode nodes, worklets, demo, build scripts and Deno tests).
 - Add test helpers and headless fakes to support Deno testing (`test_globals.d.ts`, `stubGlobal`, `deleteGlobal`, fake encoders/frames/framesources).

--- a/src/media/microphone_test.ts
+++ b/src/media/microphone_test.ts
@@ -174,5 +174,20 @@ Deno.test("Microphone", async (t) => {
 			assertEquals(updatedTrack === track, true);
 			assertEquals(track.readyState, "live");
 		});
+
+		await st.step("switchDevice updates preferred device ID and stops old track", async () => {
+			using _fakeMap = setupFakeMediaDevices(devices);
+			const context = new MediaDeviceContext();
+			const mic = new Microphone(context, { enabled: true });
+
+			const track = await mic.getAudioTrack();
+			assertEquals(track.readyState, "live");
+
+			await mic.switchDevice("mic-2");
+
+			assertEquals(mic.preferred, "mic-2");
+			assertEquals(mic.activeDeviceId, "mic-2");
+			assertEquals(track.readyState, "ended");
+		});
 	});
 });


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `switchDevice` method in `Microphone` class.
📊 **Coverage:** The new test ensures that calling `switchDevice` correctly updates the `preferred` and `activeDeviceId` properties and correctly handles stopping the existing audio track, moving its state to `"ended"`. 
✨ **Result:** Increased test coverage for `Microphone` class and provides safety for future refactoring relating to device switching.

---
*PR created automatically by Jules for task [1200403286513471624](https://jules.google.com/task/1200403286513471624) started by @okdaichi*