### PR TITLE
🧪 test: add error handling test for requestPermission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 
 ### Added
 
+- Added an error handling test for `MediaDeviceContext.requestPermission`.
 - Migrate the repository to the Deno runtime: add `deno.json` and `deno.lock`, convert tests to `Deno.test`, and update CI workflows and VSCode tasks.
 - Add AV nodes package and media processing building blocks under `src/internal/av_nodes/` (audio/video encode & decode nodes, worklets, demo, build scripts and Deno tests).
 - Add test helpers and headless fakes to support Deno testing (`test_globals.d.ts`, `stubGlobal`, `deleteGlobal`, fake encoders/frames/framesources).

--- a/src/media/device_test.ts
+++ b/src/media/device_test.ts
@@ -43,6 +43,32 @@ Deno.test("MediaDeviceContext", async (t) => {
 		assertEquals(device.deviceId, "cam-1");
 	});
 
+	await t.step("handles requestPermission errors gracefully", async () => {
+		using _fakeMap = setupFakeMediaDevices(devices);
+		const context = new MediaDeviceContext();
+
+		// Mock getUserMedia to reject
+		const originalGetUserMedia = navigator.mediaDevices.getUserMedia;
+		navigator.mediaDevices.getUserMedia = () => Promise.reject(new Error("Permission denied"));
+
+		const originalWarn = console.warn;
+		let warnCalled = false;
+		console.warn = (...args) => {
+			if (typeof args[0] === "string" && args[0].includes("Failed to request video permission")) {
+				warnCalled = true;
+			}
+		};
+
+		try {
+			const result = await context.requestPermission("video");
+			assertEquals(result, false);
+			assertEquals(warnCalled, true);
+		} finally {
+			navigator.mediaDevices.getUserMedia = originalGetUserMedia;
+			console.warn = originalWarn;
+		}
+	});
+
 	await t.step("subscribe/unsubscribe and trigger devicechange", async () => {
 		using _fakeMap = setupFakeMediaDevices(devices);
 		const context = new MediaDeviceContext();

--- a/src/media/device_test.ts
+++ b/src/media/device_test.ts
@@ -54,7 +54,10 @@ Deno.test("MediaDeviceContext", async (t) => {
 		const originalWarn = console.warn;
 		let warnCalled = false;
 		console.warn = (...args) => {
-			if (typeof args[0] === "string" && args[0].includes("Failed to request video permission")) {
+			if (
+				typeof args[0] === "string" &&
+				args[0].includes("Failed to request video permission")
+			) {
 				warnCalled = true;
 			}
 		};


### PR DESCRIPTION
🎯 **What:** Added a missing error test for `MediaDeviceContext.requestPermission`.
📊 **Coverage:** Covered the error path when `navigator.mediaDevices.getUserMedia` fails.
✨ **Result:** Improved test coverage and ensured graceful error handling is tested.

---
*PR created automatically by Jules for task [15347314202582961233](https://jules.google.com/task/15347314202582961233) started by @okdaichi*