### PR TITLE
release(av-nodes): v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2026-07-06
+
+Patch release of `@okdaichi/av-nodes` (`packages/av_nodes`) with resource-lifecycle and correctness fixes accumulated since [0.10.1]. No API additions or breaking changes.
+
+### Fixed
+
+- `AudioDecodeNode`: schedule decoded blocks by presentation timestamp in `AudioOffloadProcessor` so bursty/jittery delivery no longer clicks/pops ([#19]).
+- `AudioDecodeNode` / `VideoDecodeNode` / `AudioEncodeNode`: close decoded frames even when processing throws, and cancel in-flight stream reads on `dispose()` so tearing down a node mid-stream no longer leaks the reader lock, buffers upstream into a dead pipe, or hangs the internal encode loop ([#23]).
+- `VideoOverlayNode` / `VideoDestinationNode` / `VideoSourceNode`: close `VideoFrame`s in `try/finally` so a throwing overlay/drawImage/constructor can't leak a GPU-backed frame; and fix the `MediaStreamVideoSourceNode` polyfill delivering ~half the configured frame rate (both the source loop and the stream `pull()` paced) ([#22]).
+- `VideoAnalyserNode`: report `frameIndex` as the cumulative input frame count (it understated by the `analysisInterval` factor); validate `analysisSize` / `historySize` / `analysisInterval` (capping `analysisSize` at 4096/side to bound allocation) ([#21]).
+- `videoEncoderConfig`: validate `width` / `height` / `frameRate` and treat an explicit `bitrate` of `0`/negative as "not set", falling back to the calculated bitrate ([#20]).
+- `AudioEncodeNode` / `VideoDecodeNode`: break busy-spin backpressure loops and cache the resolved worklet for direct per-frame posting ([#12], [#14], [#15]).
+- `@okdaichi/av-nodes` publish graph: keep benches/tests out of the published package ([#17]); force-install test doubles so the `VideoAnalyserNode` suite runs headlessly ([#16]).
+
 ## [Unreleased]
 
 This branch contains a large migration to the Deno runtime and a refactor of the AV/media and Room/elements APIs. For the full diff see the [compare view][Unreleased]. Related pull request: [#3].
@@ -88,3 +102,10 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 [#16]: https://github.com/okdaichi/moqrtc-js/pull/16
 [#17]: https://github.com/okdaichi/moqrtc-js/pull/17
 [#18]: https://github.com/okdaichi/moqrtc-js/issues/18
+[#19]: https://github.com/okdaichi/moqrtc-js/pull/19
+[#20]: https://github.com/okdaichi/moqrtc-js/pull/20
+[#21]: https://github.com/okdaichi/moqrtc-js/pull/21
+[#22]: https://github.com/okdaichi/moqrtc-js/pull/22
+[#23]: https://github.com/okdaichi/moqrtc-js/pull/23
+[0.10.1]: https://github.com/okdaichi/moqrtc-js/releases/tag/av-nodes/v0.10.1
+[0.10.2]: https://github.com/okdaichi/moqrtc-js/compare/av-nodes/v0.10.1...av-nodes/v0.10.2

--- a/packages/av_nodes/deno.json
+++ b/packages/av_nodes/deno.json
@@ -1,6 +1,6 @@
 {
 	"name": "@okdaichi/av-nodes",
-	"version": "0.10.1",
+	"version": "0.10.2",
 	"exports": {
 		".": "./mod.ts"
 	},


### PR DESCRIPTION
@Patch release of `@okdaichi/av-nodes` (packages/av_nodes).

- Bump version `0.10.1` → `0.10.2` (patch — bug fixes only, no API/breaking changes).
- Add a `[0.10.2]` section to CHANGELOG.md covering PRs #12, #14–#17, #19–#23.

Highlights: timestamp-scheduled audio playback (#19), close frames on throw + cancel streams on dispose (#22, #23), `frameIndex`/validation fixes in `VideoAnalyserNode` (#21), `videoEncoderConfig` validation (#20).

After merge this will be tagged `av-nodes/v0.10.2` and published to JSR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@