### PR TITLE
🧪 Add edge case test for defineRoom warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 - Fix failing `VideoAnalyserNode` test block — force-install the `OffscreenCanvas`/`requestIdleCallback` test doubles regardless of native presence, since Deno's native `OffscreenCanvas.getContext("2d")` returns null headlessly ([#16]).
 - Fix `@okdaichi/av-nodes` publish graph: benchmark harnesses (and, due to a root-only glob, ~20 test/fake files) were being published to jsr. Gate `encode_bench.ts`'s runner behind `import.meta.main` and exclude `**/*_bench.ts` / `**/*_test.ts` from `publish.exclude` ([#17]).
 - Fix clicks/pops on bursty or jittery audio in `AudioDecodeNode` — `AudioOffloadProcessor` now schedules each decoded block at its presentation timestamp (derived playout frame) instead of writing contiguously at arrival. Gaps are silence-filled, late/overlapping blocks are dropped, and bursts are absorbed up to one buffer of look-ahead, so playback is no longer governed by arrival cadence. The lag cushion is anchored to the first block's arrival frame (so a late first decode still gets a full cushion instead of silencing the node forever), partially-late/pre-base timestamps are clamped to the read pointer (avoids a negative-offset crash that would kill the worklet's message handler), and the playback clock advances on every render quantum including edge-state guard paths ([#18]).
+- Add missing test for edge case in `defineRoom` where custom element already exists.
 
 ### Changed
 

--- a/src/elements/room_test.ts
+++ b/src/elements/room_test.ts
@@ -246,6 +246,29 @@ Deno.test("RoomElement - constructor", async () => {
 	}
 });
 
+Deno.test("defineRoom - logs warning if already defined", async () => {
+	const { restoreDOM, roomModule } = await createRoomModuleFixture();
+	const originalWarn = console.warn;
+	let warnCalled = false;
+	let warnMessage = "";
+
+	console.warn = (msg: string) => {
+		warnCalled = true;
+		warnMessage = msg;
+	};
+
+	try {
+		// createRoomModuleFixture already defined the default "hang-room"
+		roomModule.defineRoom();
+
+		assert(warnCalled);
+		assertEquals(warnMessage, "Custom element with name hang-room is already defined.");
+	} finally {
+		console.warn = originalWarn;
+		restoreDOM();
+	}
+});
+
 Deno.test("RoomElement - observedAttributes", async () => {
 	const { restoreDOM, roomModule } = await createRoomModuleFixture();
 	try {


### PR DESCRIPTION
🎯 **What:** Added an edge case test in `src/elements/room_test.ts` to verify that `defineRoom` correctly logs a `console.warn` when a custom element with the specified name has already been defined.
📊 **Coverage:** The test ensures that calling `defineRoom` multiple times invokes the else branch, providing coverage for this error handling/warning path.
✨ **Result:** Improved test coverage and verification of edge-case behaviors for component registration.

---
*PR created automatically by Jules for task [10238269787687046613](https://jules.google.com/task/10238269787687046613) started by @okdaichi*