### PR TITLE
🧪 Add error test for RoomElement onjoin handler failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This branch contains a large migration to the Deno runtime and a refactor of the AV/media and Room/elements APIs. For the full diff see the [compare view][Unreleased]. Related pull request: [#3].
 
 ### Added
+- Add missing test for `RoomElement.onjoin` error handling.
 
 - Migrate the repository to the Deno runtime: add `deno.json` and `deno.lock`, convert tests to `Deno.test`, and update CI workflows and VSCode tasks.
 - Add AV nodes package and media processing building blocks under `src/internal/av_nodes/` (audio/video encode & decode nodes, worklets, demo, build scripts and Deno tests).

--- a/src/elements/room_test.ts
+++ b/src/elements/room_test.ts
@@ -362,6 +362,41 @@ Deno.test("RoomElement - onjoin callback fires when member joins", async () => {
 	}
 });
 
+Deno.test("RoomElement - onjoin handler failure sets error status", async () => {
+	const { restoreDOM, element } = await createRoomElementFixture();
+	try {
+		element.setAttribute("room-id", "test-room");
+
+		let statusCalled = false;
+		let statusArg: RoomLifecycleStatus | undefined;
+		element.onstatus = (status) => {
+			if (status.type === "error") {
+				statusCalled = true;
+				statusArg = status;
+			}
+		};
+
+		element.onjoin = () => {
+			throw new Error("test error");
+		};
+
+		await element.join(
+			createFakeSession("test-room", "test-publisher", {
+				includeRemote: true,
+			}) as unknown as Session,
+			{ name: "test-publisher", serveTrack: () => {} },
+		);
+		await Promise.resolve();
+
+		assert(statusCalled);
+		assertExists(statusArg);
+		assertEquals(statusArg.type, "error");
+		assert(statusArg.message.includes("onjoin handler failed: test error"));
+	} finally {
+		restoreDOM();
+	}
+});
+
 Deno.test("RoomElement - onleave callback fires when member leaves", async () => {
 	const { restoreDOM, element } = await createRoomElementFixture();
 	try {


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap in `src/elements/room.ts` where failures in the `RoomElement.onjoin` user-provided handler were not explicitly tested. The handler correctly catches errors and updates the room lifecycle status to "error", but this behavior needed validation to prevent regressions.

📊 **Coverage:** A new test "RoomElement - onjoin handler failure sets error status" is introduced in `src/elements/room_test.ts`. This test verifies the scenario where a consumer of `RoomElement` sets an `onjoin` callback that throws an exception, and asserts that the `onstatus` callback is correctly fired with type "error" and the corresponding error message.

✨ **Result:** Test coverage for the `RoomElement` lifecycle and error management is improved, ensuring robustness when integrating user-provided callbacks.

---
*PR created automatically by Jules for task [12673229337181568353](https://jules.google.com/task/12673229337181568353) started by @okdaichi*