### PR TITLE
🧪 [testing improvement] Add tests for BroadcastSubscriber.#readCatalog error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 
 ### Added
 
+- Add unit tests for `BroadcastSubscriber.#readCatalog` error handling.
 - Migrate the repository to the Deno runtime: add `deno.json` and `deno.lock`, convert tests to `Deno.test`, and update CI workflows and VSCode tasks.
 - Add AV nodes package and media processing building blocks under `src/internal/av_nodes/` (audio/video encode & decode nodes, worklets, demo, build scripts and Deno tests).
 - Add test helpers and headless fakes to support Deno testing (`test_globals.d.ts`, `stubGlobal`, `deleteGlobal`, fake encoders/frames/framesources).

--- a/src/broadcast_test.ts
+++ b/src/broadcast_test.ts
@@ -87,6 +87,66 @@ Deno.test("BroadcastSubscriber.catalog parses MSF catalog payload", async () => 
 	assertEquals(closeCodes, [SubscribeErrorCode.InternalError]);
 });
 
+Deno.test("BroadcastSubscriber.catalog handles readFrame error", async () => {
+	const closeCodes: number[] = [];
+	const expectedErr = new Error("readFrame error");
+
+	const session = {
+		subscribe: async () => [
+			{
+				acceptGroup: async () => [
+					{
+						readFrame: async (_sink: (bytes: Uint8Array) => void) => {
+							return expectedErr;
+						},
+					},
+					undefined,
+				],
+				closeWithError: async (code: number) => {
+					closeCodes.push(code);
+				},
+			},
+			undefined,
+		],
+	} as unknown as Session;
+
+	const subscriber = new BroadcastSubscriber("/room/alice.hang", "room", session);
+	const err = await subscriber.catalog();
+
+	assertEquals(err, expectedErr);
+	assertEquals(closeCodes, [SubscribeErrorCode.InternalError]);
+});
+
+Deno.test("BroadcastSubscriber.catalog handles missing payload", async () => {
+	const closeCodes: number[] = [];
+
+	const session = {
+		subscribe: async () => [
+			{
+				acceptGroup: async () => [
+					{
+						readFrame: async (_sink: (bytes: Uint8Array) => void) => {
+							return undefined; // no payload via sink
+						},
+					},
+					undefined,
+				],
+				closeWithError: async (code: number) => {
+					closeCodes.push(code);
+				},
+			},
+			undefined,
+		],
+	} as unknown as Session;
+
+	const subscriber = new BroadcastSubscriber("/room/alice.hang", "room", session);
+	const err = await subscriber.catalog();
+
+	assertExists(err);
+	assertEquals((err as Error).message, "catalog payload missing");
+	assertEquals(closeCodes, [SubscribeErrorCode.InternalError]);
+});
+
 Deno.test("BroadcastSubscriber.subscribeTrack returns TrackReader directly", async () => {
 	const calls: string[] = [];
 	const session = {


### PR DESCRIPTION
🎯 **What:** Added tests to verify error handling behavior in `BroadcastSubscriber.#readCatalog` when `readFrame` fails or returns a missing payload.
📊 **Coverage:** The test suite now explicitly covers lines 104-105 (when `readFrame` returns a frame error) and lines 107-109 (when `readFrame` resolves successfully but no payload is read from the sink).
✨ **Result:** Improved test reliability and ensured that `BroadcastSubscriber.catalog()` gracefully returns meaningful errors when encountering malformed or missing MSF catalog frames.

---
*PR created automatically by Jules for task [6292497867910901961](https://jules.google.com/task/6292497867910901961) started by @okdaichi*