### PR TITLE
🧪 [testing improvement] Add test for BroadcastSubscriber.close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 
 ### Added
 
+- Add test for `BroadcastSubscriber.close` in `src/broadcast_test.ts` to increase coverage.
 - Migrate the repository to the Deno runtime: add `deno.json` and `deno.lock`, convert tests to `Deno.test`, and update CI workflows and VSCode tasks.
 - Add AV nodes package and media processing building blocks under `src/internal/av_nodes/` (audio/video encode & decode nodes, worklets, demo, build scripts and Deno tests).
 - Add test helpers and headless fakes to support Deno testing (`test_globals.d.ts`, `stubGlobal`, `deleteGlobal`, fake encoders/frames/framesources).
@@ -21,7 +22,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 
 ### Fixed
 
-- `VideoAnalyserNode`: report `frameIndex` as the cumulative *input* frame count (it previously counted only analyzed frames, so with `analysisInterval > 1` it understated the true frame number); validate `analysisSize` / `historySize` / `analysisInterval` (0 or non-integer values previously produced `NaN` metrics or silently disabled analysis; `analysisSize` is also capped at 4096 per side to prevent a multi-hundred-MB allocation from an oversized value).
+- `VideoAnalyserNode`: report `frameIndex` as the cumulative _input_ frame count (it previously counted only analyzed frames, so with `analysisInterval > 1` it understated the true frame number); validate `analysisSize` / `historySize` / `analysisInterval` (0 or non-integer values previously produced `NaN` metrics or silently disabled analysis; `analysisSize` is also capped at 4096 per side to prevent a multi-hundred-MB allocation from an oversized value).
 - `videoEncoderConfig` now validates `width` / `height` / `frameRate` (negative or non-finite values previously produced a negative computed bitrate forwarded to the encoder) and treats an explicit `bitrate` of `0` or negative as "not set", falling back to the calculated bitrate instead of configuring the encoder with bitrate 0.
 - Close `VideoFrame`s on throw across the video pipeline (`VideoOverlayNode`, `VideoDestinationNode`, `VideoSourceNode`) so a throwing overlay function, `drawImage`, or `VideoFrame` constructor can no longer leak a GPU-backed frame; and stop the `MediaStreamVideoSourceNode` polyfill from pacing frames twice (it delivered ~half the configured frame rate because both the source loop and the stream `pull()` awaited the next frame).
 - Close decoded audio frames even when processing throws, and cancel in-flight decode/encode stream reads on `dispose()` in `AudioDecodeNode`/`VideoDecodeNode`/`AudioEncodeNode` so tearing down a node mid-stream no longer leaks the reader lock, buffers upstream into a dead pipe, or hangs the internal encode loop.

--- a/src/broadcast_test.ts
+++ b/src/broadcast_test.ts
@@ -105,3 +105,35 @@ Deno.test("BroadcastSubscriber.subscribeTrack returns TrackReader directly", asy
 	assertEquals(reader.trackName, "camera");
 	assertEquals(calls, []);
 });
+
+Deno.test("BroadcastSubscriber.close cancels the internal context", async () => {
+	let contextDonePromise: Promise<void> | undefined;
+
+	const session = {
+		subscribe: async () => [
+			{
+				acceptGroup: async (done: Promise<void>) => {
+					contextDonePromise = done;
+					await done;
+					return [undefined, new Error("catalog group canceled")];
+				},
+				closeWithError: async (_code: number) => {},
+			},
+			undefined,
+		],
+	} as unknown as Session;
+
+	const subscriber = new BroadcastSubscriber("/room/alice.hang", "room", session);
+	const catalogPromise = subscriber.catalog();
+
+	// Wait for the subscribe/acceptGroup to be called
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	assertExists(contextDonePromise);
+
+	await subscriber.close(new Error("Test close"));
+
+	const result = await catalogPromise;
+	assertEquals(result instanceof Error, true);
+	assertEquals((result as Error).message, "catalog group canceled");
+});


### PR DESCRIPTION
🎯 **What:** Added a missing test for `BroadcastSubscriber.close` to verify that it correctly cancels the internal context.
📊 **Coverage:** Covered the `close` method in `BroadcastSubscriber` and improved overall line and function coverage in `src/broadcast.ts`.
✨ **Result:** Improved test coverage and reliability for subscriber lifecycle management by ensuring context is aborted successfully upon close.

---
*PR created automatically by Jules for task [14081768842563670124](https://jules.google.com/task/14081768842563670124) started by @okdaichi*