### PR TITLE
🧪 [test] Add missing test for Screen.getAudioTrack error path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 
 ### Fixed
 
+- Add missing unit test for the `Screen.getAudioTrack` error path.
 - `VideoAnalyserNode`: report `frameIndex` as the cumulative *input* frame count (it previously counted only analyzed frames, so with `analysisInterval > 1` it understated the true frame number); validate `analysisSize` / `historySize` / `analysisInterval` (0 or non-integer values previously produced `NaN` metrics or silently disabled analysis; `analysisSize` is also capped at 4096 per side to prevent a multi-hundred-MB allocation from an oversized value).
 - `videoEncoderConfig` now validates `width` / `height` / `frameRate` (negative or non-finite values previously produced a negative computed bitrate forwarded to the encoder) and treats an explicit `bitrate` of `0` or negative as "not set", falling back to the calculated bitrate instead of configuring the encoder with bitrate 0.
 - Close `VideoFrame`s on throw across the video pipeline (`VideoOverlayNode`, `VideoDestinationNode`, `VideoSourceNode`) so a throwing overlay function, `drawImage`, or `VideoFrame` constructor can no longer leak a GPU-backed frame; and stop the `MediaStreamVideoSourceNode` polyfill from pacing frames twice (it delivered ~half the configured frame rate because both the source loop and the stream `pull()` awaited the next frame).

--- a/src/media/screen_test.ts
+++ b/src/media/screen_test.ts
@@ -66,6 +66,16 @@ Deno.test("Screen", async (t) => {
 			const audioTrack = await screen.getAudioTrack();
 			assertEquals(audioTrack, undefined);
 		});
+
+		await st.step("throws when not enabled", async () => {
+			using _fakeMap = setupFakeMediaDevices([]);
+			const screen = new Screen({ enabled: false });
+			await assertRejects(
+				() => screen.getAudioTrack(),
+				Error,
+				"Screen capture is not enabled",
+			);
+		});
 	});
 
 	await t.step("close", async (st) => {


### PR DESCRIPTION
🎯 **What:** Added a missing test for the `Screen.getAudioTrack` error path. Previously, the error path for `getAudioTrack()` on a disabled `Screen` was unchecked.
📊 **Coverage:** The scenario where `getAudioTrack()` is called while the screen capture is not enabled is now fully tested, just like `getVideoTrack()`.
✨ **Result:** Test coverage for `Screen`'s error paths is now complete, reducing the risk of regressions.

---
*PR created automatically by Jules for task [2763095753000577252](https://jules.google.com/task/2763095753000577252) started by @okdaichi*