### PR TITLE
🧪 test: add test for Camera.switchDevice

### DIFF
--- a/src/media/camera_test.ts
+++ b/src/media/camera_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
+import { assertSpyCall, assertSpyCalls, spy } from "@std/testing/mock";
 import { Camera } from "./camera.ts";
-import { MediaDeviceContext } from "./device.ts";
+import { Device, MediaDeviceContext } from "./device.ts";
 import { setupFakeMediaDevices } from "./fake_media_devices_test.ts";
 
 Deno.test("Camera", async (t) => {
@@ -89,6 +90,27 @@ Deno.test("Camera", async (t) => {
 			await assertRejects(
 				() => camera.getVideoTrack(),
 			);
+		});
+	});
+
+	await t.step("switchDevice", async (t) => {
+		await t.step("delegates to device.switchDevice", async () => {
+			using _env = setupFakeMediaDevices([]);
+			const ctx = new MediaDeviceContext();
+			const camera = new Camera(ctx);
+
+			const deviceSwitchSpy = spy(Device.prototype, "switchDevice");
+
+			try {
+				await camera.switchDevice("new-device-id");
+
+				assertSpyCalls(deviceSwitchSpy, 1);
+				assertSpyCall(deviceSwitchSpy, 0, {
+					args: ["new-device-id"],
+				});
+			} finally {
+				deviceSwitchSpy.restore();
+			}
 		});
 	});
 


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `Camera.switchDevice` method in `src/media/camera.ts`, which simply delegates to the internal `#device` instance.
📊 **Coverage:** The test ensures that calling `switchDevice` on the camera correctly passes the `deviceId` to the internal device's `switchDevice` implementation.
✨ **Result:** Enhanced test coverage and prevented future regressions involving device switching logic within the `Camera` class.

---
*PR created automatically by Jules for task [4609598771817918969](https://jules.google.com/task/4609598771817918969) started by @okdaichi*