### PR TITLE
feat(log): add @qumo/log media-domain logging package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2026-07-06
+
+First release of `@qumo/log` (`packages/log`) — a media-domain logging library for real-time media apps (Media over QUIC, audio/video streaming, WebCodecs). Stack-agnostic: no dependency on WebCodecs/WebTransport/MSE/WebRTC/`@qumo/moq`.
+
+### Added
+
+- **Generic engine:** tagged `createLogger`, levels `trace..error` with runtime `setLevel(level, tag?)` (global or per-tag), structured fields kept as-is so suppressed logs pay nothing to build, consecutive message-only dedup into a `×N` entry, `throttle()` rate-limiting (1s default window), `counter()` aggregation, a 1024-entry preallocated ring buffer + `exportLogs()` (text/ndjson, `Error` fields serialized), pluggable sinks (built-in console), and `onLogs()`/`onLevelChange()` hooks. Counter/meter handles are cached per name so repeated lookups don't allocate.
+- **Media layer:** curated `MediaTags` (audio/video/encoder/decoder/renderer/capture/transport/network/moq/quic/webtransport/jitter/catalog); typed meters on a shared 1s pulse — `meter.fps()`/`bitrate()` (auto bps/kbps/Mbps/Gbps)/`rate()`/`gauge()` (avg/min/max) — where `mark()`/`sample()` are O(1) and zero-allocation (safe in per-frame loops); media-timestamp (PTS) stamping via `createMediaLogger(tag, { clock })` and `frame()`; `formatMediaTime`/`formatBitrate` helpers.
+- **Hot-path contract:** every log method is a single numeric level compare before any argument's contents are touched; production quietness is `setLevel("warn")`. Zero runtime deps; no `import.meta.env` coupling; the single flush timer unrefs in Deno so it can't hang tests/SSR.
+
 ## [0.10.3] - 2026-07-06
 
 Patch release of `@okdaichi/av-nodes` (`packages/av_nodes`). Audio robustness fix for live/bursty ingest.

--- a/packages/log/README.md
+++ b/packages/log/README.md
@@ -1,0 +1,182 @@
+# @qumo/log
+
+A small, fast logging library for **real-time media apps** — Media over QUIC, audio/video streaming,
+WebCodecs pipelines. It speaks the media vocabulary natively (fps, bitrate, jitter, frame PTS,
+decode queues) instead of forcing every app to rebuild the same ad-hoc stats plumbing.
+
+- **Media-domain first.** Curated subsystem tags, typed meters (`fps`/`bitrate`/`rate`/`gauge`), and
+  media-timestamp (PTS) stamping on every log line.
+- **Hot-path safe.** Every log method is a single numeric level compare before anything is touched;
+  `meter.mark()` / `gauge.sample()` are O(1) and allocate nothing — safe inside per-frame
+  decode/encode loops.
+- **Stack-agnostic.** No dependency on WebCodecs, WebTransport, MSE, WebRTC, or `@qumo/moq`. You
+  feed it numbers; it produces the rates and summaries a media pipeline needs.
+- **Zero runtime dependencies.** Usable as-is from Deno, Vite, Webpack, esbuild, or a plain
+  `<script>`. Does not touch `import.meta.env`.
+
+## Install
+
+Deno / [jsr](https://jsr.io):
+
+```ts
+import { createMediaLogger, MediaTags, setLevel } from "jsr:@qumo/log@^0.1";
+```
+
+Node (via [jsr npm compatibility](https://jsr.io/docs/npm-compatibility)):
+
+```sh
+npx jsr add @qumo/log
+```
+
+## Quick start
+
+```ts
+import { createMediaLogger, MediaTags } from "@qumo/log";
+
+// A video-decode logger bound to the stream's media clock (µs). Every entry it
+// emits carries `mts` so logs align to the stream timeline, not wall-clock.
+const log = createMediaLogger(MediaTags.video, { clock: () => mediaTimeUs });
+
+log.info("decoder configured", { codec: "avc1.42E01E", width: 1280, height: 720 });
+log.frame("info", "keyframe", { pts, type: "key" }); // pts becomes mts
+log.error("decode failed", { err }); // Error survives exportLogs()
+```
+
+Output (via the built-in console sink):
+
+```
+[video] t=00:00:01.500 decoder configured { codec: 'avc1.42E01E', ... }
+[video] t=00:00:02.000 keyframe { pts: 2000000, type: 'key' }
+```
+
+## Per-frame metrics (the meters)
+
+Do **not** call `log.debug()` inside a decode/encode loop — JS evaluates the arguments before the
+call, so even a suppressed log pays for them. Use the meters instead. `mark()`/`sample()` only bump
+a number; a shared 1s timer flushes one readable summary line per active meter.
+
+```ts
+const log = createMediaLogger(MediaTags.video);
+
+const fps = log.meter.fps("decode"); // → "decode: 30.0 fps (total 900)"
+const br = log.meter.bitrate("egress"); // → "egress: 2.40 Mbps"  (mark with bytes)
+const resets = log.meter.rate("subscribe resets"); // → "subscribe resets: 5.0/s (total 5)"
+const jitter = log.meter.gauge("jitter", { unit: "ms" }); // → "jitter: avg 12.3ms (min 4ms, max 31ms)"
+
+for await (const frame of group.frames()) {
+	fps.mark();
+	br.mark(frame.bytes);
+	jitter.sample(rttMs);
+}
+```
+
+| Meter                       | Call            | Flushes                                              |
+| --------------------------- | --------------- | ---------------------------------------------------- |
+| `meter.fps(name)`           | `mark([n])`     | `<name>: 30.0 fps (total 900)`                       |
+| `meter.bitrate(name)`       | `mark(byteLen)` | `<name>: 2.40 Mbps` (auto-scales bps/kbps/Mbps/Gbps) |
+| `meter.rate(name)`          | `mark([n])`     | `<name>: 5.0/s (total 5)`                            |
+| `meter.gauge(name, {unit})` | `sample(value)` | `<name>: avg 12.3ms (min 4ms, max 31ms)`             |
+
+All meters flush once per second on a single shared timer, regardless of how many you create.
+
+## Levels & tags
+
+Levels: `trace < debug < info < warn < error`. Default global level is `info`. Runtime control:
+
+```ts
+setLevel("debug"); // global
+setLevel("trace", MediaTags.video); // one tag (per-tag override)
+setLevel("warn"); // production: quiet everything below warn
+getLevel(MediaTags.video);
+```
+
+Curated tags: `audio`, `video`, `encoder`, `decoder`, `renderer`, `capture`, `transport`, `network`,
+`moq`, `quic`, `webtransport`, `jitter`, `catalog` (see `MediaTags`). Dotted children like
+`"video.decode"` work and are independently tunable. Free-form strings are also accepted.
+
+## Structured fields & media time
+
+Pass an object as the second argument — values are kept as-is and only formatted at emit time, so
+**suppressed logs pay nothing to build**:
+
+```ts
+log.info("frame", { seq, bytes, keyframe: true });
+```
+
+When a `clock` is bound to a media logger, every entry records `mts` (media timestamp, µs) alongside
+the wall-clock `ts`. `frame(level, msg, { pts, ... })` uses the `pts` field as the media timestamp
+directly — the accurate choice for frame events. Exports and the console render media time as a
+stream timecode (`t=HH:MM:SS.mmm`).
+
+## Noisy logs
+
+Message-only repeats collapse into one `×N` entry automatically. For noisy _structured_ logs,
+rate-limit:
+
+```ts
+log.throttle("warn", "jitter high", { ms: 52 }, 200); // ≤ once / 200ms; drops counted
+```
+
+## Ring buffer & export
+
+The last 1024 entries are retained in a fixed ring buffer. Drain it for a bug report — calling this
+never loses logs:
+
+```ts
+exportLogs(); // human-readable transcript (includes media timecodes)
+exportLogs({ json: true }); // newline-delimited JSON
+retainedLogCount();
+```
+
+`Error` field values are serialized (`name`/`message`/`stack`) so they survive the export (where
+`JSON.stringify` would otherwise render `{}`).
+
+Wire it into a "Copy logs" button or a dev-only console handle:
+
+```ts
+Object.assign(globalThis, { qumoLog: { setLevel, getLevel, exportLogs } });
+```
+
+## Sinks & live view
+
+The built-in console sink is always installed. Register more (e.g. a batched HTTP shipper) with
+`addSink(fn)`. A reactive debug UI subscribes without coupling to any framework:
+
+```ts
+addSink((entry) => ship(entry)); // your transport
+const off = onLogs((entry) => append(entry)); // every emitted entry
+const off2 = onLevelChange(() => refresh()); // level changes
+```
+
+## Generic engine (for non-media reuse)
+
+`@qumo/log` is media-first, but the underlying engine is a fine generic logger too.
+`createLogger(tag)` and `counter()` are exported and carry no media semantics — useful for mixed
+apps or non-media code paths.
+
+## API
+
+| Export                                         | Kind            | Purpose                                                              |
+| ---------------------------------------------- | --------------- | -------------------------------------------------------------------- |
+| `createMediaLogger(tag, { clock? })`           | → `MediaLogger` | Media logger: levels + `frame()` + `meter` (fps/bitrate/rate/gauge). |
+| `createLogger(tag)`                            | → `Logger`      | Generic tagged logger (levels + `throttle`/`counter`).               |
+| `MediaTags`                                    | const           | Curated media subsystem tag strings.                                 |
+| `formatBitrate(bps)` / `formatMediaTime(µs)`   | fn              | Unit helpers.                                                        |
+| `setLevel(level, tag?)` / `getLevel(tag?)`     | fn              | Runtime level (global or per-tag).                                   |
+| `exportLogs({ json? })` / `retainedLogCount()` | fn              | Drain the ring buffer.                                               |
+| `addSink(fn)` / `removeSink(fn)`               | fn              | Register/remove an output sink.                                      |
+| `addFlush(fn)`                                 | fn              | Hook the shared 1s pulse (custom aggregators).                       |
+| `onLogs(fn)` / `onLevelChange(fn)`             | fn              | Subscribe; return unsubscribe.                                       |
+
+## Performance notes
+
+- Suppressed log = one numeric compare + return. Set the level to `warn` (or higher) in production.
+- Call-site arguments are still evaluated before the call, so keep `msg`/`fields` cheap; use
+  `meter.*()` for genuinely high-rate data.
+- The ring buffer is preallocated and reused — no growing array, no per-entry GC pressure beyond the
+  single entry object per emitted log.
+- One flush timer for the whole library, no matter how many counters/meters exist.
+
+## License
+
+MIT

--- a/packages/log/deno.json
+++ b/packages/log/deno.json
@@ -1,0 +1,65 @@
+{
+	"name": "@qumo/log",
+	"version": "0.1.0",
+	"exports": {
+		".": "./mod.ts"
+	},
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/okdaichi/moqrtc-js",
+		"directory": "packages/log"
+	},
+	"description": "Media-domain logging for real-time media apps (Media over QUIC, audio/video streaming, WebCodecs): tagged, level-filtered, structured, with fps/bitrate/gauge meters, PTS media-time stamping, and a ring buffer for bug-report export.",
+	"keywords": [
+		"logging",
+		"logger",
+		"media",
+		"moq",
+		"quic",
+		"webcodecs",
+		"video",
+		"audio",
+		"streaming",
+		"webrtc"
+	],
+	"compilerOptions": {
+		"lib": ["ESNext", "deno.ns", "DOM", "dom.iterable", "dom.asynciterable"],
+		"strict": true,
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		"verbatimModuleSyntax": true
+	},
+	"tasks": {
+		"check": "deno check **/*.ts",
+		"test": "deno test --allow-all",
+		"publish": "deno publish"
+	},
+	"fmt": {
+		"useTabs": true,
+		"lineWidth": 100,
+		"indentWidth": 4,
+		"singleQuote": false,
+		"semiColons": true,
+		"proseWrap": "preserve"
+	},
+	"lint": {
+		"rules": {
+			"tags": ["recommended"]
+		}
+	},
+	"publish": {
+		"exclude": [
+			"**/*_test.ts"
+		]
+	},
+	"imports": {
+		"@std/assert": "jsr:@std/assert@^1.0.19"
+	}
+}

--- a/packages/log/deno.lock
+++ b/packages/log/deno.lock
@@ -1,0 +1,23 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@^1.0.19"
+    ]
+  }
+}

--- a/packages/log/log.ts
+++ b/packages/log/log.ts
@@ -1,0 +1,436 @@
+// @qumo/log — a small, fast logging engine for real-time media apps (Media over
+// QUIC, audio/video streaming), usable in the browser and Deno.
+//
+// This module is the generic engine: levels, tags, a ring buffer, dedup,
+// throttle, sinks, export, and a shared "pulse" that periodic aggregators
+// (generic counters and the media meters in media.ts) hook into so a single 1s
+// timer flushes every summary line. The media-domain API lives in media.ts.
+//
+// Hot-path contract — read this before logging from a tight loop:
+//   - Every public method reduces to a single numeric level compare before any
+//     argument's *contents* are touched. When the level is suppressed the cost
+//     is that compare plus a return: no closure allocation, no object spread, no
+//     formatting. Setting the level to "warn" in production makes every
+//     trace/debug/info call a near-no-op.
+//   - NOTE: JavaScript evaluates a call's arguments *before* the call itself, so
+//     a suppressed log still pays to evaluate its `msg` and `fields` expressions.
+//     Keep those cheap (string literals, small field objects). For genuinely
+//     high-rate data — e.g. per-video-frame diagnostics — use the meters in
+//     media.ts (mark()/sample() only bump a number), or counter()/throttle().
+//
+// Zero runtime dependencies; does not touch `import.meta.env`. Production
+// quietness is a runtime level concern (setLevel); build-time dead-code
+// elimination of call sites, if desired, is the consumer's bundler choice.
+
+/** Structured fields attached to a log entry. Values are kept as-is and only
+ *  formatted by a sink at emit time, so suppressed logs pay nothing to build. */
+export type Fields = Record<string, unknown>;
+
+const NUM_LEVEL = {
+	trace: 0,
+	debug: 1,
+	info: 2,
+	warn: 3,
+	error: 4,
+} as const;
+
+export type LogLevel = keyof typeof NUM_LEVEL;
+type LevelNum = (typeof NUM_LEVEL)[LogLevel];
+
+const LEVEL_NAME: readonly LogLevel[] = ["trace", "debug", "info", "warn", "error"];
+
+/** A single buffered/observed log entry.
+ *
+ *  - `count` is how many consecutive identical (level,tag,msg) emits this record
+ *    represents after dedup.
+ *  - `mts` is an optional media timestamp in microseconds (e.g. a frame PTS),
+ *    stamped by the media logger so logs align to the stream timeline rather
+ *    than wall-clock. Omitted by the generic logger. */
+export interface LogEntry {
+	readonly ts: number;
+	readonly mts?: number;
+	readonly level: LogLevel;
+	readonly tag: string;
+	readonly msg: string;
+	readonly fields?: Fields;
+	count: number;
+}
+
+/** Output target — a bare function. The built-in console sink is always
+ *  installed; register more (e.g. a batched HTTP shipper) via addSink(). */
+export type Sink = (entry: LogEntry) => void;
+
+const RING_SIZE = 1024;
+const ring: LogEntry[] = [];
+let ringHead = 0; // next write index; once full, overwrites the oldest entry
+let totalWritten = 0;
+
+// Last emitted entry, for consecutive-run dedup of message-only logs.
+let lastEntry: LogEntry | null = null;
+
+// --- level store ---------------------------------------------------------
+
+let globalThreshold: LevelNum = NUM_LEVEL.info;
+const tagThreshold = new Map<string, LevelNum>();
+const levelListeners = new Set<() => void>();
+
+function thresholdFor(tag: string): LevelNum {
+	return tagThreshold.get(tag) ?? globalThreshold;
+}
+
+/** Set the runtime level — globally, or for a single tag.
+ *  Per-tag overrides win over the global threshold. Passing no tag resets any
+ *  per-tag overrides when changing the global level. */
+export function setLevel(level: LogLevel, tag?: string): void {
+	const n = NUM_LEVEL[level];
+	if (tag) {
+		tagThreshold.set(tag, n);
+	} else {
+		globalThreshold = n;
+		tagThreshold.clear();
+	}
+	for (const fn of levelListeners) fn();
+}
+
+/** Effective level for a tag (per-tag override if set, else global). */
+export function getLevel(tag?: string): LogLevel {
+	const n = tag ? (tagThreshold.get(tag) ?? globalThreshold) : globalThreshold;
+	return LEVEL_NAME[n] ?? "info";
+}
+
+/** Subscribe to level changes (e.g. for a reactive debug UI). Returns an
+ *  unsubscribe function. */
+export function onLevelChange(fn: () => void): () => void {
+	levelListeners.add(fn);
+	return () => {
+		levelListeners.delete(fn);
+	};
+}
+
+// --- sinks ---------------------------------------------------------------
+
+const sinks: Sink[] = [consoleSink];
+
+/** Register an additional output sink (e.g. a batched HTTP shipper). */
+export function addSink(sink: Sink): void {
+	sinks.push(sink);
+}
+
+/** Remove a previously-registered sink. */
+export function removeSink(sink: Sink): void {
+	const i = sinks.indexOf(sink);
+	if (i >= 0) sinks.splice(i, 1);
+}
+
+// --- entry subscribers (live view, tests) --------------------------------
+
+const entrySubs = new Set<(entry: LogEntry) => void>();
+
+/** Observe every emitted entry in real time. The entry object is reused by the
+ *  ring buffer — read it synchronously, don't retain it. Returns unsubscribe. */
+export function onLogs(fn: (entry: LogEntry) => void): () => void {
+	entrySubs.add(fn);
+	return () => {
+		entrySubs.delete(fn);
+	};
+}
+
+// --- core ----------------------------------------------------------------
+
+function pushRing(entry: LogEntry): void {
+	if (ring.length < RING_SIZE) {
+		ring.push(entry);
+	} else {
+		ring[ringHead] = entry;
+	}
+	ringHead = (ringHead + 1) % RING_SIZE;
+	totalWritten++;
+}
+
+/** Emit a log entry directly (used by the media layer and wrappers). Returns
+ *  nothing. Respects the level gate, dedup, sinks, ring buffer, and
+ *  subscribers exactly like a Logger method. */
+export function emit(
+	level: LogLevel,
+	tag: string,
+	msg: string,
+	fields?: Fields,
+	mts?: number,
+): void {
+	coreLog(level, tag, msg, fields, mts);
+}
+
+function coreLog(
+	level: LogLevel,
+	tag: string,
+	msg: string,
+	fields?: Fields,
+	mts?: number,
+): void {
+	const levelNum = NUM_LEVEL[level];
+	if (levelNum < thresholdFor(tag)) return;
+
+	// Dedup consecutive identical message-only emits: bump the last record's
+	// count instead of pushing a new line. Structured logs (with fields) always
+	// emit — they carry per-occurrence detail worth seeing; throttle() handles
+	// noisy structured logs. Media-timestamped entries always emit too (their mts
+	// is per-occurrence and meaningful).
+	if (!fields && mts === undefined && lastEntry !== null) {
+		const l = lastEntry;
+		if (
+			l.level === level && l.tag === tag && l.msg === msg && !l.fields &&
+			l.mts === undefined
+		) {
+			l.count++;
+			return;
+		}
+	}
+
+	const entry: LogEntry = {
+		ts: Date.now(),
+		...(mts !== undefined ? { mts } : {}),
+		level,
+		tag,
+		msg,
+		...(fields ? { fields } : {}),
+		count: 1,
+	};
+	pushRing(entry);
+	lastEntry = entry;
+
+	for (const fn of entrySubs) fn(entry);
+	for (const s of sinks) s(entry);
+}
+
+// --- pulse: shared 1s flush for periodic aggregators ---------------------
+//
+// Generic counters (counter()) and the media meters (media.ts) both need a
+// periodic flush. They register a hook here; a single lazily-started 1s timer
+// drives all of them, so there is ever only one timer regardless of how many
+// call sites aggregate.
+
+const PULSE_MS = 1000;
+const flushHooks = new Set<() => void>();
+let pulseTimer: ReturnType<typeof setInterval> | undefined;
+
+// setInterval keeps the host alive. In a browser tab that's fine; in Deno
+// (tests/SSR) we unref it so the library can't hang process exit. Browsers have
+// no unref concept and the page owns the lifetime, so the call is a no-op there.
+function setUnrefInterval(fn: () => void, ms: number): ReturnType<typeof setInterval> {
+	const id = setInterval(fn, ms);
+	const g = globalThis as { Deno?: { unrefTimer?: (id: unknown) => void } };
+	g.Deno?.unrefTimer?.(id);
+	return id;
+}
+
+/** Register a hook to be called once per second (on the shared pulse timer).
+ *  The first registration starts the timer. Returns an unsubscribe function. */
+export function addFlush(hook: () => void): () => void {
+	flushHooks.add(hook);
+	if (!pulseTimer) {
+		pulseTimer = setUnrefInterval(() => {
+			for (const h of flushHooks) h();
+		}, PULSE_MS);
+	}
+	return () => {
+		flushHooks.delete(hook);
+	};
+}
+
+// --- counter (generic aggregation) ---------------------------------------
+//
+// mark() only bumps a number; the shared pulse flushes one summary line per
+// active counter. For media-domain rates (fps/bitrate) and gauges, prefer the
+// meters in media.ts.
+
+export interface Counter {
+	/** Bump the counter by n (default 1). Allocation-free, safe on the hot path. */
+	mark(n?: number): void;
+}
+
+interface CounterState {
+	readonly tag: string;
+	readonly name: string;
+	delta: number;
+	total: number;
+}
+
+const counters: CounterState[] = [];
+let counterHookRegistered = false;
+
+function ensureCounterHook(): void {
+	if (counterHookRegistered) return;
+	counterHookRegistered = true;
+	addFlush(() => {
+		for (const c of counters) {
+			const delta = c.delta;
+			if (delta === 0) continue;
+			c.delta = 0;
+			emit("info", c.tag, `${c.name}: ${delta}/s (total ${c.total})`);
+		}
+	});
+}
+
+// --- logger façade -------------------------------------------------------
+
+export interface Logger {
+	trace(msg: string, fields?: Fields): void;
+	debug(msg: string, fields?: Fields): void;
+	info(msg: string, fields?: Fields): void;
+	warn(msg: string, fields?: Fields): void;
+	error(msg: string, fields?: Fields): void;
+	/** Explicit level (used by wrappers/tests). */
+	log(level: LogLevel, msg: string, fields?: Fields): void;
+	/** Emit at most once per windowMs (default 1s); subsequent calls within the
+	 *  window are dropped and counted, with the drop total folded into the next
+	 *  emit. Keyed by msg within this logger. Use for noisy structured logs. */
+	throttle(level: LogLevel, msg: string, fields?: Fields, windowMs?: number): void;
+	/** Register a named counter — a generic events/sec aggregator. mark() is O(1)
+	 *  and allocates nothing. For fps/bitrate/jitter, prefer the media meters.
+	 *  The handle is cached per (tag, name), so calling counter() repeatedly is
+	 *  also free — safe to write `log.counter("x").mark()` inline. */
+	counter(name: string): Counter;
+}
+
+/** Create a tagged logger. `tag` is the category — e.g. "subscribe",
+ *  "subscribe.video", "transport". Dotted tags read naturally in the console
+ *  and in exported logs, and can be level-tuned independently via setLevel. */
+export function createLogger(tag: string): Logger {
+	// throttle state, keyed by msg within this logger
+	const throttleState = new Map<string, { until: number; dropped: number }>();
+	// counter handles, cached per name so repeated lookups don't allocate.
+	const counterCache = new Map<string, Counter>();
+
+	return {
+		trace: (msg, fields) => coreLog("trace", tag, msg, fields),
+		debug: (msg, fields) => coreLog("debug", tag, msg, fields),
+		info: (msg, fields) => coreLog("info", tag, msg, fields),
+		warn: (msg, fields) => coreLog("warn", tag, msg, fields),
+		error: (msg, fields) => coreLog("error", tag, msg, fields),
+		log: (level, msg, fields) => coreLog(level, tag, msg, fields),
+		throttle: (level, msg, fields, windowMs = 1000) => {
+			const now = Date.now();
+			const st = throttleState.get(msg);
+			if (st && now < st.until) {
+				st.dropped++;
+				return;
+			}
+			const dropped = st?.dropped ?? 0;
+			const entryFields: Fields = { ...fields };
+			if (dropped > 0) entryFields.dropped = dropped;
+			coreLog(level, tag, msg, Object.keys(entryFields).length ? entryFields : undefined);
+			throttleState.set(msg, { until: now + windowMs, dropped: 0 });
+		},
+		counter: (name) => {
+			let handle = counterCache.get(name);
+			if (handle) return handle;
+			let state = counters.find((c) => c.tag === tag && c.name === name);
+			if (!state) {
+				state = { tag, name, delta: 0, total: 0 };
+				counters.push(state);
+				ensureCounterHook();
+			}
+			const s = state;
+			handle = {
+				mark(n = 1) {
+					s.delta += n;
+					s.total += n;
+				},
+			};
+			counterCache.set(name, handle);
+			return handle;
+		},
+	};
+}
+
+// --- export (bug reports) ------------------------------------------------
+
+function pad2(n: number): string {
+	return n < 10 ? `0${n}` : String(n);
+}
+
+function pad3(n: number): string {
+	return n < 10 ? `00${n}` : n < 100 ? `0${n}` : String(n);
+}
+
+function formatTs(ts: number): string {
+	const d = new Date(ts);
+	return (
+		`${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}` +
+		"." + pad3(d.getMilliseconds())
+	);
+}
+
+/** Format a media timestamp (microseconds) as a stream timecode HH:MM:SS.mmm. */
+export function formatMediaTime(mts: number): string {
+	const totalSec = Math.floor(mts / 1_000_000);
+	const h = Math.floor(totalSec / 3600);
+	const m = Math.floor((totalSec % 3600) / 60);
+	const s = totalSec % 60;
+	const ms = Math.floor((mts / 1000) % 1000);
+	return `${pad2(h)}:${pad2(m)}:${pad2(s)}.${pad3(ms)}`;
+}
+
+// JSON.stringify replacer that surfaces Error fields (name/message/stack), which
+// are non-enumerable and would otherwise serialize as {} — unacceptable for a
+// bug-report export where the error is usually the point. Runs only at export.
+function errorReplacer(_key: string, value: unknown): unknown {
+	if (value instanceof Error) {
+		return { name: value.name, message: value.message, stack: value.stack };
+	}
+	return value;
+}
+
+function formatEntry(e: LogEntry): string {
+	const count = e.count > 1 ? ` ×${e.count}` : "";
+	const mtime = e.mts !== undefined ? ` t=${formatMediaTime(e.mts)}` : "";
+	const head = `${formatTs(e.ts)} [${e.level.toUpperCase()}] [${e.tag}]${count}${mtime} ${e.msg}`;
+	if (!e.fields) return head;
+	try {
+		return `${head} ${JSON.stringify(e.fields, errorReplacer)}`;
+	} catch {
+		return `${head} <unserializable fields>`;
+	}
+}
+
+/** Drain the ring buffer to a human-readable transcript for bug reports. Order
+ *  is oldest→newest. The buffer is left intact — calling this never loses logs.
+ *  Pass { json: true } for a newline-delimited-JSON dump. */
+export function exportLogs(opts?: { json?: boolean }): string {
+	const have = Math.min(totalWritten, ring.length);
+	if (have === 0) return opts?.json ? "" : "(no logs)";
+	const lines: string[] = [];
+	for (let i = 0; i < have; i++) {
+		// ringHead points at the oldest entry once full, else at ring.length.
+		const idx = ring.length < RING_SIZE ? i : (ringHead + i) % RING_SIZE;
+		const e = ring[idx];
+		if (!e) continue;
+		lines.push(opts?.json ? JSON.stringify(e, errorReplacer) : formatEntry(e));
+	}
+	return lines.join("\n");
+}
+
+/** Current number of entries retained (capped at RING_SIZE). */
+export function retainedLogCount(): number {
+	return Math.min(totalWritten, ring.length);
+}
+
+// --- console sink --------------------------------------------------------
+
+const CONSOLE_METHOD: Record<LogLevel, "debug" | "info" | "warn" | "error"> = {
+	trace: "debug",
+	debug: "debug",
+	info: "info",
+	warn: "warn",
+	error: "error",
+};
+
+function consoleSink(e: LogEntry): void {
+	const fn = console[CONSOLE_METHOD[e.level]];
+	const mtime = e.mts !== undefined ? ` t=${formatMediaTime(e.mts)}` : "";
+	const prefix = `[${e.tag}]${e.count > 1 ? ` ×${e.count}` : ""}${mtime}`;
+	// Pass fields as a separate inspectable argument rather than stringifying —
+	// keeps objects expandable in devtools.
+	if (e.fields) fn(prefix, e.msg, e.fields);
+	else fn(prefix, e.msg);
+}

--- a/packages/log/log_test.ts
+++ b/packages/log/log_test.ts
@@ -1,0 +1,181 @@
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+
+import {
+	addSink,
+	createLogger,
+	exportLogs,
+	getLevel,
+	type LogEntry,
+	onLevelChange,
+	onLogs,
+	removeSink,
+	retainedLogCount,
+	setLevel,
+} from "./log.ts";
+
+// Most tests install a capturing sink to observe emitted entries. Each test is
+// responsible for removing its sink so they don't leak into siblings.
+function capturingSink(): { sink: (e: LogEntry) => void; entries: LogEntry[] } {
+	const entries: LogEntry[] = [];
+	const sink = (e: LogEntry) => entries.push(e);
+	return { sink, entries };
+}
+
+Deno.test("level gate: info is the default; trace/debug suppressed", () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	const log = createLogger("t");
+	log.trace("t");
+	log.debug("d");
+	log.info("i");
+	removeSink(sink);
+	assertEquals(entries.length, 1);
+	assertEquals(entries[0]!.msg, "i");
+});
+
+Deno.test("setLevel('trace') surfaces all levels, including trace/debug", () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	setLevel("trace");
+	const log = createLogger("t2");
+	log.trace("t");
+	log.debug("d");
+	log.info("i");
+	log.warn("w");
+	log.error("e");
+	setLevel("info"); // restore global default
+	removeSink(sink);
+	assertEquals(entries.length, 5);
+});
+
+Deno.test("per-tag override wins over global and is readable via getLevel", () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	setLevel("info"); // global
+	setLevel("debug", "video"); // per-tag
+	const video = createLogger("video");
+	const audio = createLogger("audio");
+	video.debug("v"); // emitted (per-tag debug)
+	audio.debug("a"); // suppressed (global info)
+	assertEquals(getLevel("video"), "debug");
+	assertEquals(getLevel("audio"), "info");
+	removeSink(sink);
+	assertEquals(entries.length, 1);
+	assertEquals(entries[0]!.msg, "v");
+});
+
+Deno.test("dedup collapses consecutive identical message-only emits into one ×N entry", () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	const log = createLogger("d");
+	log.warn("noisy");
+	log.warn("noisy");
+	log.warn("noisy");
+	log.warn("other");
+	removeSink(sink);
+	// Sink sees the first occurrence; the repeats only bump the buffer count.
+	assertEquals(entries.filter((e) => e.msg === "noisy").length, 1);
+	assertEquals(entries.find((e) => e.msg === "other")?.count, 1);
+	// The accumulated count is visible in the ring buffer / export.
+	assert(/×3/.test(exportLogs()));
+});
+
+Deno.test("structured logs always emit (never deduped)", () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	const log = createLogger("s");
+	log.info("struct", { n: 1 });
+	log.info("struct", { n: 2 });
+	removeSink(sink);
+	assertEquals(entries.length, 2);
+});
+
+Deno.test("throttle emits once per window and carries buffered drops on the next emit", async () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	const log = createLogger("th");
+	log.throttle("warn", "spam", { i: 1 }, 60);
+	log.throttle("warn", "spam", { i: 2 }, 60);
+	log.throttle("warn", "spam", { i: 3 }, 60);
+	assertEquals(entries.length, 1);
+	await new Promise((r) => setTimeout(r, 80));
+	log.throttle("warn", "spam", { i: 4 }, 60);
+	removeSink(sink);
+	assertEquals(entries.length, 2);
+	assertEquals((entries[1]!.fields as { dropped: number }).dropped, 2);
+});
+
+Deno.test("counter.mark is O(1) and tracks delta + total (flushed by the 1s timer)", async () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	const log = createLogger("c");
+	const frames = log.counter("frames");
+	frames.mark();
+	frames.mark(5);
+	// mark() must not have emitted anything itself.
+	assertEquals(entries.length, 0);
+	// Wait for the aggregator's 1s flush.
+	await new Promise((r) => setTimeout(r, 1100));
+	removeSink(sink);
+	const flush = entries.find((e) => e.msg.startsWith("frames:"));
+	assert(flush, "counter flushed a summary line");
+	assert(/6\/s \(total 6\)/.test(flush.msg), `flush message: ${flush.msg}`);
+});
+
+Deno.test("exportLogs: text format pairs dedup count with the message; json == ndjson", () => {
+	const log = createLogger("ex");
+	log.warn("repeat");
+	log.warn("repeat");
+	log.error("boom", { err: new Error("x") });
+	const txt = exportLogs();
+	assert(/×2[^\n]*repeat/.test(txt), `text export pairs ×2 with repeat: ${txt}`);
+	const json = exportLogs({ json: true });
+	assertEquals(json.split("\n").length, retainedLogCount());
+	// Errors are serialized (name/message/stack), not {}.
+	assert(json.includes('"message":"x"'), `error serialized in json export: ${json}`);
+});
+
+Deno.test("onLogs observes emitted entries synchronously", () => {
+	const seen: LogEntry[] = [];
+	const off = onLogs((e) => seen.push(e));
+	const log = createLogger("obs");
+	log.info("hello");
+	off();
+	log.info("after-unsubscribe");
+	assertEquals(seen.length, 1);
+	assertEquals(seen[0]!.msg, "hello");
+});
+
+Deno.test("onLevelChange fires when the level changes", () => {
+	let calls = 0;
+	const off = onLevelChange(() => calls++);
+	setLevel("warn");
+	setLevel("error", "x"); // per-tag change also fires
+	off();
+	setLevel("info"); // not observed after unsubscribe
+	assertNotEquals(calls, 0);
+});
+
+Deno.test("counter() returns a cached handle — repeated lookups don't allocate", () => {
+	const log = createLogger("cache");
+	const a = log.counter("events");
+	const b = log.counter("events");
+	assert(a === b, "same handle returned for the same name");
+	a.mark(3);
+	b.mark(4); // same underlying state
+	// Distinct names get distinct handles.
+	assert(log.counter("other") !== a);
+});
+
+Deno.test("throttle defaults to a 1s window when windowMs is omitted", () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	const log = createLogger("td");
+	log.throttle("warn", "once"); // no fields, no windowMs
+	log.throttle("warn", "once");
+	removeSink(sink);
+	assertEquals(entries.length, 1); // second call suppressed by the 1s default
+});
+
+Deno.test("addSink/removeSink", () => {
+});

--- a/packages/log/media.ts
+++ b/packages/log/media.ts
@@ -1,0 +1,283 @@
+// @qumo/log — media-domain layer.
+//
+// The generic engine (log.ts) speaks the vocabulary of any app: levels, tags,
+// messages, fields. This layer speaks the vocabulary of real-time media:
+// curated subsystem tags, typed meters (fps / bitrate / rate / gauge), media
+// timestamps (frame PTS) stamped onto every log, and a frame() shortcut.
+//
+// It is stack-agnostic: it does not import or depend on WebCodecs, WebTransport,
+// MSE, WebRTC, or @qumo/moq. The caller feeds it numbers (frame counts, byte
+// counts, PTS, queue depths) and it produces the rates and summaries a media
+// pipeline needs. Nothing here runs on the per-frame hot path beyond bumping a
+// number — mark()/sample() are O(1) and allocation-free; the shared 1s pulse in
+// log.ts does the formatting and emission.
+
+import {
+	addFlush,
+	type Counter,
+	createLogger,
+	emit,
+	type Fields,
+	type Logger,
+	type LogLevel,
+} from "./log.ts";
+
+/** Curated media subsystem tags. Use directly or as the base of a dotted child
+ *  (e.g. `${MediaTags.video}.decode`). Free-form strings are still accepted
+ *  everywhere — these are just the common ones, spelled once. */
+export const MediaTags = {
+	audio: "audio",
+	video: "video",
+	encoder: "encoder",
+	decoder: "decoder",
+	renderer: "renderer",
+	capture: "capture",
+	transport: "transport",
+	network: "network",
+	moq: "moq",
+	quic: "quic",
+	webtransport: "webtransport",
+	jitter: "jitter",
+	catalog: "catalog",
+} as const;
+export type MediaTag = (typeof MediaTags)[keyof typeof MediaTags];
+
+// --- meters --------------------------------------------------------------
+//
+// Four kinds, all flushed once per second by the shared pulse:
+//   fps     — counts frames;            flushes "<name>: <n.n> fps (total N)"
+//   bitrate — accumulates bytes;        flushes "<name>: <X.XX Mbps>"
+//   rate    — counts events;            flushes "<name>: <n.n>/s (total N)"
+//   gauge   — samples an instant value; flushes "<name>: avg X (min A, max B)"
+
+type MeterKind = "fps" | "bitrate" | "rate" | "gauge";
+
+// meter.fps / meter.bitrate / meter.rate return a Counter (re-imported from
+// log.ts — a mark()-able handle). meter.gauge returns a Gauge (sample()-able).
+// Unifying the counting handle with the generic Counter avoids a redundant type.
+
+/** Handle returned by meter.gauge. sample() is O(1) (keeps a running
+ *  min/max/sum/count for the window — no per-sample allocation). */
+export interface Gauge {
+	sample(value: number): void;
+}
+
+export interface MeterOptions {
+	/** Suffix appended to gauge summaries (e.g. "ms", " frames"). fps/bitrate
+	 *  derive their own units and ignore this. Options apply on first creation
+	 *  only — the handle is cached per (tag, kind, name). */
+	unit?: string;
+}
+
+interface MeterState {
+	readonly tag: string;
+	readonly name: string;
+	readonly kind: MeterKind;
+	readonly unit?: string;
+	// counters (fps / rate / bitrate): delta = frames | events | bytes this window
+	delta: number;
+	total: number;
+	// gauge: running aggregates for the window
+	gCount: number;
+	gSum: number;
+	gMin: number;
+	gMax: number;
+}
+
+const meters: MeterState[] = [];
+let meterHookRegistered = false;
+
+function ensureMeterHook(): void {
+	if (meterHookRegistered) return;
+	meterHookRegistered = true;
+	const secs = 1; // pulse interval is 1s (PULSE_MS in log.ts)
+	addFlush(() => {
+		for (const m of meters) {
+			switch (m.kind) {
+				case "fps": {
+					if (m.delta === 0) break;
+					const per = m.delta / secs;
+					emit("info", m.tag, `${m.name}: ${per.toFixed(1)} fps (total ${m.total})`);
+					m.delta = 0;
+					break;
+				}
+				case "rate": {
+					if (m.delta === 0) break;
+					const per = m.delta / secs;
+					emit("info", m.tag, `${m.name}: ${per.toFixed(1)}/s (total ${m.total})`);
+					m.delta = 0;
+					break;
+				}
+				case "bitrate": {
+					if (m.delta === 0) break;
+					// delta is bytes this window → bits per second.
+					const bps = (m.delta * 8) / secs;
+					emit("info", m.tag, `${m.name}: ${formatBitrate(bps)}`);
+					m.delta = 0;
+					break;
+				}
+				case "gauge": {
+					if (m.gCount === 0) break;
+					const avg = m.gSum / m.gCount;
+					const unit = m.unit ?? "";
+					emit(
+						"info",
+						m.tag,
+						`${m.name}: avg ${round1(avg)}${unit} (min ${round1(m.gMin)}${unit}, max ${
+							round1(m.gMax)
+						}${unit})`,
+					);
+					m.gCount = 0;
+					m.gSum = 0;
+					m.gMin = Number.POSITIVE_INFINITY;
+					m.gMax = Number.NEGATIVE_INFINITY;
+					break;
+				}
+			}
+		}
+	});
+}
+
+function registerMeter(
+	tag: string,
+	name: string,
+	kind: MeterKind,
+	opts?: MeterOptions,
+): MeterState {
+	let state = meters.find((m) => m.tag === tag && m.name === name && m.kind === kind);
+	if (!state) {
+		state = {
+			tag,
+			name,
+			kind,
+			unit: opts?.unit,
+			delta: 0,
+			total: 0,
+			gCount: 0,
+			gSum: 0,
+			gMin: Number.POSITIVE_INFINITY,
+			gMax: Number.NEGATIVE_INFINITY,
+		};
+		meters.push(state);
+		ensureMeterHook();
+	}
+	return state;
+}
+
+function meterHandle(state: MeterState): Counter {
+	return {
+		mark(n = 1) {
+			state.delta += n;
+			state.total += n;
+		},
+	};
+}
+
+function gaugeHandle(state: MeterState): Gauge {
+	return {
+		sample(value: number) {
+			state.gCount++;
+			state.gSum += value;
+			if (value < state.gMin) state.gMin = value;
+			if (value > state.gMax) state.gMax = value;
+		},
+	};
+}
+
+function round1(n: number): string {
+	return (Math.round(n * 10) / 10).toString();
+}
+
+/** Human-readable bitrate from bits-per-second. */
+export function formatBitrate(bps: number): string {
+	if (bps < 1000) return `${Math.round(bps)} bps`;
+	if (bps < 1_000_000) return `${(bps / 1_000).toFixed(1)} kbps`;
+	if (bps < 1_000_000_000) return `${(bps / 1_000_000).toFixed(2)} Mbps`;
+	return `${(bps / 1_000_000_000).toFixed(2)} Gbps`;
+}
+
+// --- media logger --------------------------------------------------------
+
+export interface MediaMeterNamespace {
+	/** Frame counter → flushes "<name>: <n.n> fps (total N)" once per second. */
+	fps(name: string): Counter;
+	/** Byte accumulator → flushes "<name>: <X.XX Mbps>" once per second.
+	 *  mark(byteLength) per frame. */
+	bitrate(name: string): Counter;
+	/** Generic event counter → flushes "<name>: <n.n>/s (total N)". */
+	rate(name: string): Counter;
+	/** Instantaneous sample (decode-queue depth, RTT, jitter ms) → flushes
+	 *  "<name>: avg X (min A, max B)" once per second. */
+	gauge(name: string, opts?: MeterOptions): Gauge;
+}
+
+export interface MediaLogger extends Logger {
+	/** Emit a media-frame event. If `fields.pts` is a number it is used as the
+	 *  media timestamp (mts) for this entry — more accurate than the clock for
+	 *  frame events. Otherwise the bound clock (if any) supplies mts. Use for
+	 *  low-frequency frame events (keyframe, config change, corruption); do not
+	 *  call per-frame on a hot path — use the meters for per-frame accounting. */
+	frame(level: LogLevel, msg: string, fields?: Fields): void;
+	/** Typed media aggregators, flushed once per second by the shared pulse. */
+	readonly meter: MediaMeterNamespace;
+}
+
+export interface MediaLoggerOptions {
+	/** Supplies the current media time in microseconds, stamped as `mts` on every
+	 *  entry this logger emits (so logs align to the stream timeline). Optional;
+	 *  when unset, no media time is recorded. */
+	clock?: () => number;
+}
+
+/** Create a media-domain logger. Like createLogger(tag), but every emitted
+ *  entry carries a media timestamp (when `clock` is provided) and the logger
+ *  exposes typed meters (fps/bitrate/rate/gauge) plus a frame() shortcut.
+ *
+ *  `tag` is typically one of the {@link MediaTags} (e.g. MediaTags.video) or a
+ *  dotted child like "video.decode". */
+export function createMediaLogger(
+	tag: string | MediaTag,
+	opts?: MediaLoggerOptions,
+): MediaLogger {
+	const base = createLogger(tag);
+	const clock = opts?.clock;
+	const mts = () => clock?.();
+	const wrap = (level: LogLevel) => (msg: string, fields?: Fields) =>
+		emit(level, tag, msg, fields, mts());
+
+	// Meter handles are cached per (kind, name) so a repeated lookup (e.g.
+	// `log.meter.fps("decode").mark()` written inline in a frame loop) does not
+	// allocate a fresh handle each call. State is shared regardless.
+	const meterCache = new Map<string, Counter | Gauge>();
+	const meter = (kind: MeterKind, name: string, o?: MeterOptions) => {
+		const key = `${kind}:${name}`;
+		let handle = meterCache.get(key);
+		if (!handle) {
+			const state = registerMeter(tag, name, kind, o);
+			handle = kind === "gauge" ? gaugeHandle(state) : meterHandle(state);
+			meterCache.set(key, handle);
+		}
+		return handle;
+	};
+
+	return {
+		trace: wrap("trace"),
+		debug: wrap("debug"),
+		info: wrap("info"),
+		warn: wrap("warn"),
+		error: wrap("error"),
+		log: (level, msg, fields) => emit(level, tag, msg, fields, mts()),
+		throttle: base.throttle,
+		counter: base.counter,
+		frame: (level, msg, fields) => {
+			const pts = fields && typeof fields.pts === "number" ? fields.pts : mts();
+			emit(level, tag, msg, fields, pts);
+		},
+		meter: {
+			fps: (name: string) => meter("fps", name) as Counter,
+			bitrate: (name: string) => meter("bitrate", name) as Counter,
+			rate: (name: string) => meter("rate", name) as Counter,
+			gauge: (name: string, o?: MeterOptions) => meter("gauge", name, o) as Gauge,
+		},
+	};
+}

--- a/packages/log/media_test.ts
+++ b/packages/log/media_test.ts
@@ -1,0 +1,126 @@
+import { assert, assertEquals, assertMatch } from "@std/assert";
+
+import {
+	addSink,
+	createMediaLogger,
+	formatBitrate,
+	type LogEntry,
+	MediaTags,
+	removeSink,
+} from "./mod.ts";
+
+function capturingSink(): { sink: (e: LogEntry) => void; entries: LogEntry[] } {
+	const entries: LogEntry[] = [];
+	const sink = (e: LogEntry) => entries.push(e);
+	return { sink, entries };
+}
+
+const PULSE = 1100; // meters flush on the 1s pulse; wait a touch longer
+
+Deno.test("createMediaLogger stamps mts from the bound clock on every emit", () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	// clock returns microseconds; 1.5s → timecode 00:00:01.500
+	const log = createMediaLogger(MediaTags.video, { clock: () => 1_500_000 });
+	log.info("hello");
+	removeSink(sink);
+	assertEquals(entries.length, 1);
+	assertEquals(entries[0]!.mts, 1_500_000);
+});
+
+Deno.test("frame() uses fields.pts as the media timestamp when present", () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	const log = createMediaLogger("video", { clock: () => 999_999_999 });
+	log.frame("info", "keyframe", { pts: 2_500_000, type: "key" });
+	removeSink(sink);
+	assertEquals(entries[0]!.mts, 2_500_000); // pts wins over clock
+});
+
+Deno.test("frame() falls back to the clock when pts is absent", () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	const log = createMediaLogger("video", { clock: () => 7_500_000 });
+	log.frame("info", "config applied");
+	removeSink(sink);
+	assertEquals(entries[0]!.mts, 7_500_000);
+});
+
+Deno.test("meter.fps flushes a frames-per-second line once per second", async () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	const log = createMediaLogger(MediaTags.video);
+	const frames = log.meter.fps("decode");
+	for (let i = 0; i < 30; i++) frames.mark();
+	await new Promise((r) => setTimeout(r, PULSE));
+	removeSink(sink);
+	const flush = entries.find((e) => e.msg.startsWith("decode:"));
+	assert(flush, "fps meter flushed");
+	assertMatch(flush.msg, /^decode: 30\.0 fps \(total 30\)$/);
+});
+
+Deno.test("meter.bitrate flushes a Mbps line from accumulated bytes", async () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	const log = createMediaLogger("video");
+	const br = log.meter.bitrate("egress");
+	// 300_000 bytes/s * 8 = 2_400_000 bps = 2.40 Mbps
+	br.mark(300_000);
+	await new Promise((r) => setTimeout(r, PULSE));
+	removeSink(sink);
+	const flush = entries.find((e) => e.msg.startsWith("egress:"));
+	assert(flush, "bitrate meter flushed");
+	assertMatch(flush.msg, /^egress: 2\.40 Mbps$/);
+});
+
+Deno.test("meter.rate flushes an events-per-second line", async () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	const log = createMediaLogger("moq");
+	const drops = log.meter.rate("subscribe resets");
+	drops.mark(5);
+	await new Promise((r) => setTimeout(r, PULSE));
+	removeSink(sink);
+	const flush = entries.find((e) => e.msg.startsWith("subscribe resets:"));
+	assert(flush, "rate meter flushed");
+	assertMatch(flush.msg, /^subscribe resets: 5\.0\/s \(total 5\)$/);
+});
+
+Deno.test("meter.gauge flushes avg/min/max with a unit suffix", async () => {
+	const { sink, entries } = capturingSink();
+	addSink(sink);
+	const log = createMediaLogger(MediaTags.jitter);
+	const q = log.meter.gauge("jitter", { unit: "ms" });
+	q.sample(10);
+	q.sample(20);
+	q.sample(30); // avg 20, min 10, max 30
+	await new Promise((r) => setTimeout(r, PULSE));
+	removeSink(sink);
+	const flush = entries.find((e) => e.msg.startsWith("jitter:"));
+	assert(flush, "gauge meter flushed");
+	assertMatch(flush.msg, /^jitter: avg 20ms \(min 10ms, max 30ms\)$/);
+});
+
+Deno.test("formatBitrate picks the right unit at each threshold", () => {
+	assertEquals(formatBitrate(999), "999 bps");
+	assertEquals(formatBitrate(1500), "1.5 kbps");
+	assertEquals(formatBitrate(2_400_000), "2.40 Mbps");
+	assertEquals(formatBitrate(1_500_000_000), "1.50 Gbps");
+});
+
+Deno.test("MediaTags exposes the curated subsystem names", () => {
+	assertEquals(MediaTags.video, "video");
+	assertEquals(MediaTags.webtransport, "webtransport");
+	assertEquals(MediaTags.encoder, "encoder");
+});
+
+Deno.test("meter handles are cached — repeated lookups return the same object", () => {
+	const log = createMediaLogger("cache");
+	// Same handle per (kind, name) — so `log.meter.fps("x").mark()` inline is
+	// allocation-free after the first call.
+	assert(log.meter.fps("decode") === log.meter.fps("decode"));
+	assert(log.meter.bitrate("egress") === log.meter.bitrate("egress"));
+	assert(log.meter.gauge("jitter") === log.meter.gauge("jitter"));
+	// Different names → different handles.
+	assert(log.meter.fps("decode") !== log.meter.fps("render"));
+});

--- a/packages/log/mod.ts
+++ b/packages/log/mod.ts
@@ -1,0 +1,38 @@
+// @qumo/log — public API surface.
+//
+// A logging library for real-time media apps. The generic engine (levels, tags,
+// ring buffer, dedup, sinks, export) plus a media-domain layer (curated tags,
+// fps/bitrate/rate/gauge meters, PTS media-time stamping, frame() shortcut).
+//
+// Import from the package entry, e.g.:
+//   import { createMediaLogger, MediaTags, setLevel } from "@qumo/log";
+
+// Generic engine.
+export {
+	addFlush,
+	addSink,
+	createLogger,
+	emit,
+	exportLogs,
+	formatMediaTime,
+	getLevel,
+	onLevelChange,
+	onLogs,
+	removeSink,
+	retainedLogCount,
+	setLevel,
+} from "./log.ts";
+
+export type { Counter, Fields, LogEntry, Logger, LogLevel, Sink } from "./log.ts";
+
+// Media layer.
+export { createMediaLogger, formatBitrate, MediaTags } from "./media.ts";
+
+export type {
+	Gauge,
+	MediaLogger,
+	MediaLoggerOptions,
+	MediaMeterNamespace,
+	MediaTag,
+	MeterOptions,
+} from "./media.ts";


### PR DESCRIPTION
## Description

Adds `@qumo/log` — a self-contained logging library for **real-time media apps** (Media over QUIC, audio/video streaming, WebCodecs pipelines) — as a new package at `packages/log/`, a sibling of `packages/av_nodes`. Publishable to jsr as `@qumo/log@0.1.0`.

Media-first but **stack-agnostic**: no dependency on WebCodecs / WebTransport / MSE / WebRTC / `@qumo/moq`. The caller feeds it numbers (frame counts, bytes, PTS, queue depths) and it produces the rates and summaries a media pipeline needs. Co-locating it here groups the JS-side qumo libraries together (`@okdaichi/av-nodes`, `@okdaichi/moqrtc-js`, and now `@qumo/log`), each published independently from its own `packages/` directory.

> **Canonical home.** This is where the library lives. (An earlier draft was opened in the qumo relay repo at qumo-dev/qumo#243 — now closed — because a TS library doesn't belong at the root of that primarily-Go repo. The implementation here is the refined version.)

## Usage

```ts
import { createMediaLogger, MediaTags, setLevel, exportLogs } from "@qumo/log";

// A video-decode logger bound to the stream's media clock (µs). Every entry it
// emits carries `mts` so logs align to the stream timeline, not wall-clock.
const log = createMediaLogger(MediaTags.video, { clock: () => mediaTimeUs });

log.info("decoder configured", { codec: "avc1.42E01E", width: 1280, height: 720 });
log.frame("info", "keyframe", { pts, type: "key" }); // pts becomes the media timestamp
log.error("decode failed", { err });                  // Error fields survive exportLogs()
```

```
[video] t=00:00:01.500 decoder configured { codec: 'avc1.42E01E', width: 1280, height: 720 }
[video] t=00:00:02.000 keyframe { pts: 2000000, type: 'key' }
```

Per-frame metrics use typed meters — `mark()`/`sample()` are O(1) and allocate nothing, so they're safe inside decode/encode loops. A single shared 1s timer flushes one readable line per active meter:

```ts
const fps = log.meter.fps("decode");                   // → "decode: 30.0 fps (total 900)"
const br = log.meter.bitrate("egress");                // → "egress: 2.40 Mbps"   (mark with bytes)
const resets = log.meter.rate("subscribe resets");     // → "subscribe resets: 5.0/s (total 5)"
const jitter = log.meter.gauge("jitter", { unit: "ms" }); // → "jitter: avg 12.3ms (min 4ms, max 31ms)"

for await (const frame of group.frames()) {
  fps.mark();
  br.mark(frame.bytes);
  jitter.sample(rttMs);
}
```

Levels are a runtime control (`setLevel("warn")` in production makes every trace/debug/info call a no-op), and recent logs are exportable for bug reports. The generic engine (`createLogger`, `counter()`) is also exported for non-media code paths. See `packages/log/README.md` for the full API.

## Related Issue

Closes #

## Changes

- New `packages/log/` package (`deno.json`, `mod.ts`, `log.ts`, `log_test.ts`, `media.ts`, `media_test.ts`, `README.md`, `deno.lock`), publishable to jsr as `@qumo/log@0.1.0`. `deno.json` mirrors `packages/av_nodes` (name, `repository.directory`, description, keywords, `publish.exclude` for tests, `imports`).
- Generic engine (`log.ts`), public and reusable: levels `trace..error`, runtime `setLevel(level, tag?)` (global or per-tag); structured fields kept as-is so suppressed logs pay nothing to build; consecutive message-only dedup into one `×N` entry; `throttle()` rate-limiting (1s default window); `counter()` aggregation; 1024-entry preallocated ring buffer + `exportLogs()` (text/ndjson, `Error` fields serialized); pluggable sinks (built-in console); `onLogs()`/`onLevelChange()` hooks. Optional `LogEntry.mts` (media timestamp, µs), exported `emit()`, and a shared 1s pulse (`addFlush`) that all periodic aggregators hook into — one timer for the whole library.
- Media layer (`media.ts`): curated `MediaTags`; typed meters (`meter.fps`/`bitrate`/`rate`/`gauge`) with O(1) zero-alloc `mark()`/`sample()` safe in per-frame loops; PTS media-time stamping via `createMediaLogger(tag, { clock })` and `frame()`; `formatMediaTime`/`formatBitrate` helpers.
- Counter and meter handles are cached per name, so repeated lookups (e.g. `log.meter.fps("x").mark()` written inline) don't allocate after the first call.
- CHANGELOG: `[0.1.0]` section for the new package.

## Testing

How was this tested:

    cd packages/log
    deno fmt               # clean
    deno lint              # clean
    deno check **/*.ts     # clean (under the repo's strict compiler config, incl. noUncheckedIndexedAccess)
    deno test --allow-read # 23 passed | 0 failed
    deno publish --dry-run # Success (publishable as @qumo/log@0.1.0)

Coverage (23 tests): level gating + per-tag overrides, dedup `×N`, throttle drop-buffering + default window, generic counter flush, handle caching (counter + meters), export (text/ndjson + `Error` serialization), `onLogs`/`onLevelChange`, sink add/remove; and the media layer — PTS stamping from the bound clock and from `frame()`'s `pts` field, all four meter kinds (fps/bitrate/rate/gauge) flush formatting, `formatBitrate` thresholds, and `MediaTags`. The shared pulse is unref'd so the suite exits cleanly.

Not done here: publishing to jsr (left to the maintainer, pending final scope ownership — `@qumo/log` since `@qumo/moq` is the precedent); wiring it into a consumer.

## Checklist

- [x] Comments added for complex logic
- [x] Documentation updated if needed
- [x] Tests added/updated
