### PR TITLE
fix(av-nodes): stop encode loop instead of spinning when encode() throws

### DIFF
--- a/packages/av_nodes/audio/encode_node.ts
+++ b/packages/av_nodes/audio/encode_node.ts
@@ -212,10 +212,17 @@ export class AudioEncodeNode extends GainNode {
 		try {
 			this.#encoder.encode(value);
 		} catch (e) {
-			// Only log if not a closed codec error during shutdown
+			// encode() throws InvalidStateError on an unconfigured codec — e.g.
+			// the caller never called configure() (or configure failed) yet is
+			// still routing audio in. Rescheduling would spin here forever,
+			// logging the same error once per frame. Stop the loop instead; a
+			// later configure() must re-encodeTo() to restart it.
 			if (!this.#disposed) {
-				console.error("[AudioEncodeNode] encode error:", e);
+				console.error("[AudioEncodeNode] encode error — stopping loop:", e);
 			}
+			value.close();
+			stream.releaseLock();
+			return;
 		}
 
 		value.close();

--- a/packages/av_nodes/audio/encode_node_test.ts
+++ b/packages/av_nodes/audio/encode_node_test.ts
@@ -734,6 +734,45 @@ Deno.test("AudioEncodeNode - worklet #next path", async (t) => {
 		encoder.dispatchEvent(new Event("dequeue"));
 	});
 
+	await t.step(
+		"#next stops the loop (does not spin) when encode() throws",
+		async () => {
+			const encoder = FakeAudioEncoder.lastCreated!;
+			encoder.encodeCalls = [];
+			encoder.encodeQueueSize = 0;
+
+			// Simulate the failure mode from the field: encode() throws on an
+			// unconfigured codec. A thrown error must NOT make #next reschedule
+			// forever, logging the same error once per posted frame.
+			let attempts = 0;
+			const encodeSlot = encoder as unknown as {
+				encode: (data: AudioData) => void;
+			};
+			const originalEncode = encodeSlot.encode;
+			encodeSlot.encode = (_data: AudioData) => {
+				attempts++;
+				throw new Error(
+					"Cannot call 'encode' on an unconfigured codec.",
+				);
+			};
+
+			try {
+				postFrame(1);
+				postFrame(2);
+				postFrame(3);
+				// Let any queued microtasks drain.
+				await new Promise<void>((r) => setTimeout(r, 10));
+				await new Promise<void>((r) => setTimeout(r, 10));
+
+				// The loop must stop at the first failing frame — exactly one
+				// attempt — instead of retrying for each posted frame.
+				assertEquals(attempts, 1);
+			} finally {
+				encodeSlot.encode = originalEncode;
+			}
+		},
+	);
+
 	await t.step("#next stops encoding after dispose", async () => {
 		const encoder = FakeAudioEncoder.lastCreated!;
 		encoder.encodeCalls = [];


### PR DESCRIPTION
## Description

`AudioEncodeNode.#next` caught `encode()` failures only to log them and reschedule via `queueMicrotask`. On an unconfigured codec — the caller never called `configure()`, or `configure()` failed while audio is still routed in — `encode()` throws `InvalidStateError` **once per worklet frame**, so the loop logged the same error forever:

```
[AudioEncodeNode] encode error: InvalidStateError: Failed to execute 'encode' on 'AudioEncoder': Cannot call 'encode' on an unconfigured codec.
```

This is the exact spam observed in the qumo playground when switching ingest scenarios (rtmp/rtsp ↔ echo).

## Changes

- Treat a thrown `encode()` as terminal in `#next`: close the frame, release the reader, and `return` — no reschedule. A later `configure()` must re-`encodeTo()` to restart.
- Regression test: `#next stops the loop (does not spin) when encode() throws` — overrides the encoder's `encode` to throw, posts 3 frames, asserts exactly **one** attempt (not one per frame).

## Related Issue

Surfaced by qumo-dev/qumo#245, which fixes the playground-side trigger (leaked `AudioContext`s + audio routed into an unconfigured encoder) on its own. This is the library-level defense so **any** `@okdaichi/av-nodes` consumer is protected, not just the playground.

## Testing

`deno task check` clean; `deno test --allow-all` → 59 passed (204 steps), 0 failed.

## Checklist

- [x] Comments added for complex logic
- [x] Documentation updated if needed
- [x] Tests added/updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)