### PR TITLE
ci: test published packages in CI, gate publish, LF normalization, release docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalize line endings to LF on checkout and commit, regardless of OS.
+# CI runs on Linux (already LF); this stops Windows contributors from hitting
+# spurious `deno fmt --check` failures caused by git's CRLF autocrlf conversion.
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,22 @@ jobs:
           name: moqrtc-js-coverage
           fail_ci_if_error: false
           verbose: true
+
+      # The published packages live under packages/ and have their own
+      # deno.json check/test tasks. The root coverage step above only covers
+      # src/ (root test.include), so type-check and test each package here too.
+      - name: Check av-nodes
+        working-directory: packages/av_nodes
+        run: deno task check
+
+      - name: Test av-nodes
+        working-directory: packages/av_nodes
+        run: deno task test
+
+      - name: Check media-log
+        working-directory: packages/media_log
+        run: deno task check
+
+      - name: Test media-log
+        working-directory: packages/media_log
+        run: deno task test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,10 @@ jobs:
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
           echo "Publishing '$prefix' from $dir"
 
+      - name: Test (publish gate)
+        working-directory: ${{ steps.pkg.outputs.dir }}
+        run: deno task test
+
       - name: Publish to JSR
         working-directory: ${{ steps.pkg.outputs.dir }}
         run: deno publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,58 +52,7 @@ Patch release of `@okdaichi/av-nodes` (`packages/av_nodes`) with resource-lifecy
 
 ## [Unreleased]
 
-This branch contains a large migration to the Deno runtime and a refactor of the AV/media and Room/elements APIs. For the full diff see the [compare view][Unreleased]. Related pull request: [#3].
-
-### Changed
-
-- Rename the root package scope from `@okudai/moqrtc-js` to `@okdaichi/moqrtc-js` to match the `@okdaichi` scope already used by `@okdaichi/av-nodes` and `@okdaichi/golikejs`; update the root README import and fix the stale `@okudai/moq` "Related" link to the actual dependency `@qumo/moq`.
-
-### Added
-
-- Migrate the repository to the Deno runtime: add `deno.json` and `deno.lock`, convert tests to `Deno.test`, and update CI workflows and VSCode tasks.
-- Add AV nodes package and media processing building blocks under `src/internal/av_nodes/` (audio/video encode & decode nodes, worklets, demo, build scripts and Deno tests).
-- Add test helpers and headless fakes to support Deno testing (`test_globals.d.ts`, `stubGlobal`, `deleteGlobal`, fake encoders/frames/framesources).
-- Add browser-detection utilities and tests for `isChrome` and `isFirefox`.
-- Add `FakeAudioDecoder` and `FakeVideoDecoder` test doubles for decoder backpressure testing.
-- Add `AudioDecodeNode` tests covering creation, configuration, stream decoding, and backpressure scenarios.
-- Add backpressure recovery and stalled-decoder timeout tests for `VideoDecodeNode`.
-
-### Fixed
-
-- `VideoAnalyserNode`: report `frameIndex` as the cumulative _input_ frame count (it previously counted only analyzed frames, so with `analysisInterval > 1` it understated the true frame number); validate `analysisSize` / `historySize` / `analysisInterval` (0 or non-integer values previously produced `NaN` metrics or silently disabled analysis; `analysisSize` is also capped at 4096 per side to prevent a multi-hundred-MB allocation from an oversized value).
-- `videoEncoderConfig` now validates `width` / `height` / `frameRate` (negative or non-finite values previously produced a negative computed bitrate forwarded to the encoder) and treats an explicit `bitrate` of `0` or negative as "not set", falling back to the calculated bitrate instead of configuring the encoder with bitrate 0.
-- Close `VideoFrame`s on throw across the video pipeline (`VideoOverlayNode`, `VideoDestinationNode`, `VideoSourceNode`) so a throwing overlay function, `drawImage`, or `VideoFrame` constructor can no longer leak a GPU-backed frame; and stop the `MediaStreamVideoSourceNode` polyfill from pacing frames twice (it delivered ~half the configured frame rate because both the source loop and the stream `pull()` awaited the next frame).
-- Close decoded audio frames even when processing throws, and cancel in-flight decode/encode stream reads on `dispose()` in `AudioDecodeNode`/`VideoDecodeNode`/`AudioEncodeNode` so tearing down a node mid-stream no longer leaks the reader lock, buffers upstream into a dead pipe, or hangs the internal encode loop.
-- Fix infinite loop in `VideoDecodeNode` and `AudioDecodeNode` backpressure handling — replace busy `queueMicrotask` spin with event-driven `dequeue` listener and a 5-second timeout fallback ([#5]).
-- Fix infinite loop in `AudioEncodeNode` encoder backpressure — wait for the encoder `dequeue` event (with a 5-second timeout) instead of busy-spinning via `queueMicrotask`, and stop reading the stream when the drain times out ([#12]).
-- Fix failing `VideoAnalyserNode` test block — force-install the `OffscreenCanvas`/`requestIdleCallback` test doubles regardless of native presence, since Deno's native `OffscreenCanvas.getContext("2d")` returns null headlessly ([#16]).
-- Fix `@okdaichi/av-nodes` publish graph: benchmark harnesses (and, due to a root-only glob, ~20 test/fake files) were being published to jsr. Gate `encode_bench.ts`'s runner behind `import.meta.main` and exclude `**/*_bench.ts` / `**/*_test.ts` from `publish.exclude` ([#17]).
-- Fix clicks/pops on bursty or jittery audio in `AudioDecodeNode` — `AudioOffloadProcessor` now schedules each decoded block at its presentation timestamp (derived playout frame) instead of writing contiguously at arrival. Gaps are silence-filled, late/overlapping blocks are dropped, and bursts are absorbed up to one buffer of look-ahead, so playback is no longer governed by arrival cadence. The lag cushion is anchored to the first block's arrival frame (so a late first decode still gets a full cushion instead of silencing the node forever), partially-late/pre-base timestamps are clamped to the read pointer (avoids a negative-offset crash that would kill the worklet's message handler), and the playback clock advances on every render quantum including edge-state guard paths ([#18]).
-
-### Changed
-
-- Migrate many tests from Node/Vitest to Deno and remove Node-specific mocking/patch infrastructure.
-- Refactor `AudioEncodeNode` / `VideoEncodeNode` to support async output handling, Promise-returning destinations, Map-based destination management, and safer disposal semantics.
-- Refactor media APIs (`Camera`, `Microphone`, `Device`) for clearer structure and improved type safety.
-- Refactor Room / elements API and test utilities for clarity and maintainability; tests renamed/moved to follow Deno conventions.
-- Update dependencies to `@qumo/moq@0.15.0` and `@okdaichi/golikejs@0.9.0`.
-- `AudioDecodeNode`: cache the resolved worklet and post decoded frames directly instead of going through a per-frame `.then()` continuation (also guards the fast-path `postMessage` against throws so a failure can't escape into the decoder output callback) ([#14]).
-- `AudioEncodeNode`: the worklet-driven encode path (`#next`) now encodes stream-sourced frames directly instead of cloning first (the node owns those frames), cutting per-frame allocation/GC pressure; added `#next`-path test coverage and made `FakeAudioEncoder` model the `dequeue` event ([#15]).
-- Add formatting step for generated worklet files using `deno fmt`.
-
-### Removed
-
-- Removed Node.js-specific artifacts and example application files (e.g. `package-lock.json`, `pnpm-lock.yaml`, many files under `example/`).
-- Removed legacy migration-only documentation, obsolete mocks, and patch files that are no longer required.
-
-### BREAKING CHANGES
-
-- Migration to Deno and the rewrite of test utilities are breaking changes for workflows that rely on Node/Vitest. Consumers using Node-based tooling must follow migration notes and update CI/dev environments accordingly.
-
-### Notes
-
-- Branch summary: `copilot/migrate-to-deno-runtime` — ~197 files changed, ~17k insertions, ~37k deletions.
-- Major added paths: `src/internal/av_nodes/`, `src/internal/av_nodes/demo/`, `deno.json`, `deno.lock`.
+Merged work on `main` not yet cut as a tagged release. The Deno runtime migration and AV/media + Room/elements refactor landed in [#3]; the fixes and features from that work are recorded (with PR references) under the versioned `@okdaichi/av-nodes` and `@okdaichi/media-log` entries above. Full pre-release history is preserved in git.
 
 ## [0.1.0] - TBD
 
@@ -128,7 +77,7 @@ This branch contains a large migration to the Deno runtime and a refactor of the
 - **Minor version (0.X.0)**: Add functionality in a backward compatible manner
 - **Patch version (0.0.X)**: Backward compatible bug fixes
 
-[Unreleased]: https://github.com/okdaichi/moqrtc-js/compare/main...copilot/migrate-to-deno-runtime
+[Unreleased]: https://github.com/okdaichi/moqrtc-js/compare/av-nodes/v0.10.4...HEAD
 ["#3"]: https://github.com/okdaichi/moqrtc-js/pull/3
 [#5]: https://github.com/okdaichi/moqrtc-js/pull/5
 [#12]: https://github.com/okdaichi/moqrtc-js/pull/12

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ Enhancement suggestions are welcome! Please create an issue with:
 - Reference issues and pull requests when relevant
 
 Example:
+
 ```
 Add support for X feature
 
@@ -134,6 +135,51 @@ moqrtc-js/
 ├── MIGRATION_NOTES.md   # Migration documentation
 └── README.md            # Project documentation
 ```
+
+## Releasing
+
+This repo publishes two independent packages to [JSR](https://jsr.io) —
+`@okdaichi/av-nodes` (`packages/av_nodes`) and `@okdaichi/media-log`
+(`packages/media_log`). Releases are **per-package**, driven by **tags**, and
+published automatically from GitHub Actions via OIDC (no tokens or secrets
+required). The root `@okdaichi/moqrtc-js` package is not currently released.
+
+> Prerequisite: each JSR package must be linked to this repo
+> (`okdaichi/moqrtc-js`) in its JSR settings so OIDC auth works. Both packages
+> are already linked.
+
+To cut a release of one package:
+
+1. **Bump the version** in `packages/<package>/deno.json` (`version` field).
+   Follow SemVer: patch for bug fixes, minor for added functionality, major for
+   breaking changes (this is a 0.x project, so most releases are patch/minor).
+2. **Update `CHANGELOG.md`**: add a `## [X.Y.Z] - YYYY-MM-DD` entry at the top of
+   the versioned section (above the previous release), summarize the changes,
+   reference the relevant PRs (`[#NN]`), and add the PR + version-compare link
+   references at the bottom (e.g.
+   `[0.10.4]: .../compare/av-nodes/v0.10.3...av-nodes/v0.10.4`).
+3. **Commit**, e.g. `release(av-nodes): bump version to 0.10.4`.
+4. **Tag and push** the release tag — the tag name determines which package
+   publishes:
+
+   ```bash
+   git tag av-nodes/v0.10.4   # or: media-log/v0.1.0
+   git push origin av-nodes/v0.10.4
+   ```
+
+   Pushing a tag matching `av-nodes/v*` or `media-log/v*` triggers the
+   `Publish` workflow (`.github/workflows/publish.yml`), which checks out the
+   tagged commit, runs that package's tests as a gate, then runs `deno publish`.
+   The package is published at exactly the tagged version.
+
+To publish a package without a fresh tag (e.g. a tag was pushed before the
+workflow existed, or to recover from a failed publish), use the **Run workflow**
+button on the Publish workflow in GitHub Actions — it dispatches from `main`
+and is restricted to the `main` branch.
+
+CI (`ci.yml`) runs `deno fmt --check`, `deno lint`, type-checks, and the root
+`src/` tests on every push/PR to `main`, and also runs each package's
+`deno task check` + `deno task test`. Don't publish a package whose CI is red.
 
 ## Getting Help
 


### PR DESCRIPTION
## What

Four follow-ups to the release work, all surfaced during the av-nodes 0.10.4 / media-log 0.1.0 release:

- **ci.yml** — run `deno task check` + `deno task test` for `av-nodes` (59 tests) and `media-log` (23 tests). The root coverage step only covers `src/` (root `test.include`), so the two **published** packages' suites never ran in CI — a regression in either could ship untested.
- **publish.yml** — run `deno task test` as a gate before `deno publish`, so a package can't reach JSR with failing tests.
- **.gitattributes** — `* text=auto eol=lf`. Repo blobs are already LF; this stops Windows contributors from hitting spurious `deno fmt --check` failures from CRLF autocrlf conversion (hit during this release). No binaries in the tree, so one rule suffices.
- **CHANGELOG.md** — collapse the stale `[Unreleased]` block (the merged Deno-migration PR #3; its detail duplicates the versioned entries above) into a short pointer, and repoint its compare link off the dead `copilot/migrate-to-deno-runtime` branch to a live `av-nodes/v0.10.4...HEAD` compare.
- **CONTRIBUTING.md** — add a **Releasing** section documenting the per-package, tag-driven OIDC publish flow.

## Verification

- `deno task check` + `deno task test` pass for both packages locally (av-nodes 59, media-log 23).
- Both workflow YAMLs parse; `deno fmt --check` clean on touched markdown; committed blobs are LF (no `\r`).

## Not in scope

- `deno lint` is still not enforced for `packages/*` in CI — `packages/av_nodes/audio/encode_bench.ts` has a pre-existing `constructor-super` finding (dev-only bench file) that blocks adding `deno lint` for av-nodes until fixed or excluded. Flagging as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
