### PR TITLE
ci: lint published packages; refactor bench off conditional super

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,13 @@ jobs:
           verbose: true
 
       # The published packages live under packages/ and have their own
-      # deno.json check/test tasks. The root coverage step above only covers
-      # src/ (root test.include), so type-check and test each package here too.
+      # deno.json lint/check/test config. The root steps above only cover
+      # src/ (root lint/fmt/test include), so lint, type-check, and test each
+      # package here too.
+      - name: Lint av-nodes
+        working-directory: packages/av_nodes
+        run: deno lint
+
       - name: Check av-nodes
         working-directory: packages/av_nodes
         run: deno task check
@@ -50,6 +55,10 @@ jobs:
       - name: Test av-nodes
         working-directory: packages/av_nodes
         run: deno task test
+
+      - name: Lint media-log
+        working-directory: packages/media_log
+        run: deno lint
 
       - name: Check media-log
         working-directory: packages/media_log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ Patch release of `@okdaichi/av-nodes` (`packages/av_nodes`) with resource-lifecy
 
 Merged work on `main` not yet cut as a tagged release. The Deno runtime migration and AV/media + Room/elements refactor landed in [#3]; the fixes and features from that work are recorded (with PR references) under the versioned `@okdaichi/av-nodes` and `@okdaichi/media-log` entries above. Full pre-release history is preserved in git.
 
+### Changed
+
+- CI now runs `deno lint` for the published packages (`@okdaichi/av-nodes`, `@okdaichi/media-log`) alongside `check`/`test`. The one blocker — `FakeAudioDataCtor` in `packages/av_nodes/audio/encode_bench.ts` calling `super()` in both branches of an if/else — was refactored to a single unconditional `super()` via an arg-resolving helper (no behavior change) ([#48]).
+
 ## [0.1.0] - TBD
 
 ### Added
@@ -93,6 +97,7 @@ Merged work on `main` not yet cut as a tagged release. The Deno runtime migratio
 [#23]: https://github.com/okdaichi/moqrtc-js/pull/23
 [#42]: https://github.com/okdaichi/moqrtc-js/pull/42
 [#44]: https://github.com/okdaichi/moqrtc-js/pull/44
+[#48]: https://github.com/okdaichi/moqrtc-js/pull/48
 [0.1.0]: https://github.com/okdaichi/moqrtc-js/releases/tag/media-log/v0.1.0
 [0.10.1]: https://github.com/okdaichi/moqrtc-js/releases/tag/av-nodes/v0.10.1
 [0.10.2]: https://github.com/okdaichi/moqrtc-js/compare/av-nodes/v0.10.1...av-nodes/v0.10.2

--- a/packages/av_nodes/audio/encode_bench.ts
+++ b/packages/av_nodes/audio/encode_bench.ts
@@ -32,6 +32,30 @@ overrideGlobal("GainNode", FakeGainNode);
 
 // AudioData ctor that accepts either AudioDataInit (from worklet) or the
 // positional (frames, channels, sampleRate, ts) form used by FakeAudioData.
+// Args are resolved by a free function so the derived constructor has a single
+// unconditional super() call (calling super conditionally trips constructor-super).
+function resolveAudioDataCtorArgs(
+	initOrFrames?: unknown,
+	channels?: number,
+	sampleRate?: number,
+	timestamp?: number,
+): [number, number, number, number] {
+	if (typeof initOrFrames === "object" && initOrFrames !== null) {
+		const init = initOrFrames as AudioDataInit;
+		return [
+			init.numberOfFrames ?? 1024,
+			init.numberOfChannels ?? 2,
+			init.sampleRate ?? 44100,
+			init.timestamp ?? 0,
+		];
+	}
+	return [
+		(initOrFrames as number | undefined) ?? 1024,
+		channels ?? 2,
+		sampleRate ?? 44100,
+		timestamp ?? 0,
+	];
+}
 class FakeAudioDataCtor extends FakeAudioData {
 	constructor(
 		initOrFrames?: unknown,
@@ -39,24 +63,7 @@ class FakeAudioDataCtor extends FakeAudioData {
 		sampleRate?: number,
 		timestamp?: number,
 	) {
-		if (
-			typeof initOrFrames === "object" && initOrFrames !== null
-		) {
-			const init = initOrFrames as AudioDataInit;
-			super(
-				init.numberOfFrames ?? 1024,
-				init.numberOfChannels ?? 2,
-				init.sampleRate ?? 44100,
-				init.timestamp ?? 0,
-			);
-		} else {
-			super(
-				initOrFrames as number | undefined,
-				channels,
-				sampleRate,
-				timestamp,
-			);
-		}
+		super(...resolveAudioDataCtorArgs(initOrFrames, channels, sampleRate, timestamp));
 	}
 }
 overrideGlobal("AudioData", FakeAudioDataCtor);


### PR DESCRIPTION
## What

Enforce `deno lint` for the published packages in CI — the last uncovered quality gate flagged in #47.

- **`ci.yml`** — add `deno lint` steps for `av-nodes` and `media-log`, alongside the existing `check`/`test` steps. Root's `deno lint` is scoped to `src/` (root `lint.include`), so the packages were previously unlinted in CI.
- **`encode_bench.ts`** — fix the one blocker: `FakeAudioDataCtor` called `super()` in both branches of an if/else (it accepts either `AudioDataInit` from the worklet or the positional `(frames, channels, sampleRate, ts)` form). That's legitimate, but `constructor-super`'s branch analysis flags conditional `super()`. Refactored to resolve args via a free function and call `super()` once unconditionally. No ignore comment (per request), no behavior change.

## Verification

- `deno lint` clean for both packages (av-nodes 51 files, media-log 5 files) — no escape comments.
- `deno check packages/av_nodes/audio/encode_bench.ts` ✓; `deno fmt --check` ✓.
- Bench still runs and reports sane numbers (20k frames, median ~18 ms) — refactor is behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
